### PR TITLE
Curl timeout.

### DIFF
--- a/src/BotApi.php
+++ b/src/BotApi.php
@@ -194,7 +194,9 @@ class BotApi
             CURLOPT_URL => $this->getUrl() . '/' . $method,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_POST => null,
-            CURLOPT_POSTFIELDS => null
+            CURLOPT_POSTFIELDS => null,
+            CURLOPT_CONNECTTIMEOUT_MS => 2000, // 2 second.
+            CURLOPT_NOSIGNAL => TRUE,
         ];
 
         if ($data) {


### PR DESCRIPTION
Hi

First of all thanks for the script!

I have a problem on my site with timeout curl. For me once script not complete success, php output info about error "maximum execution time". In script I not find timeout for curl, propose the following solution.

Request CURL may last no more than 2 seconds. Average this time is enough.