### PR TITLE
Set CURLOPT_VERIFYPEER = false in BotApi::call method.

### DIFF
--- a/src/BotApi.php
+++ b/src/BotApi.php
@@ -193,6 +193,7 @@ class BotApi
         $options = [
             CURLOPT_URL => $this->getUrl() . '/' . $method,
             CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_VERIFYPEER => false,
             CURLOPT_POST => null,
             CURLOPT_POSTFIELDS => null
         ];


### PR DESCRIPTION
Hi.
I've got an error while trying to make a request using self-signed certificate. Here is a fix.