### PR TITLE
ArrayOfPhotoSize parsing error fixed.

### DIFF
--- a/src/Types/ArrayOfPhotoSize.php
+++ b/src/Types/ArrayOfPhotoSize.php
@@ -2,15 +2,72 @@
 
 namespace TelegramBot\Api\Types;
 
-abstract class ArrayOfPhotoSize
+use TelegramBot\Api\BaseType;
+use TelegramBot\Api\TypeInterface;
+
+class ArrayOfPhotoSize extends BaseType implements TypeInterface, \ArrayAccess, \Iterator
 {
+    protected $container = [];
+    protected $position = 0;
+
     public static function fromResponse($data)
     {
-        $arrayOfPhotoSize = [];
+        $instance = new static();
         foreach ($data as $photoSizeItem) {
-            $arrayOfPhotoSize[] = PhotoSize::fromResponse($photoSizeItem);
+            $instance->container[] = PhotoSize::fromResponse($photoSizeItem);
         }
 
-        return $arrayOfPhotoSize;
+        return $instance;
+    }
+
+    public function toJson($inner = false)
+    {
+        $output = [];
+
+        foreach ($this->container as $photo) {
+            $output[] = $photo->toJson(true);
+        }
+
+        return $inner === false ? json_encode($output) : $output;
+    }
+
+    public function offsetSet($offset, $value) {
+        if (is_null($offset)) {
+            $this->container[] = $value;
+        } else {
+            $this->container[$offset] = $value;
+        }
+    }
+
+    public function offsetExists($offset) {
+        return isset($this->container[$offset]);
+    }
+
+    public function offsetUnset($offset) {
+        unset($this->container[$offset]);
+    }
+
+    public function offsetGet($offset) {
+        return isset($this->container[$offset]) ? $this->container[$offset] : null;
+    }
+
+    function rewind() {
+        $this->position = 0;
+    }
+
+    function current() {
+        return $this->container[$this->position];
+    }
+
+    function key() {
+        return $this->position;
+    }
+
+    function next() {
+        ++$this->position;
+    }
+
+    function valid() {
+        return isset($this->container[$this->position]);
     }
 }

--- a/src/Types/Message.php
+++ b/src/Types/Message.php
@@ -124,7 +124,7 @@ class Message extends BaseType implements TypeInterface
      * Optional. Message is a photo, available sizes of the photo
      * array of \TelegramBot\Api\Types\Photo
      *
-     * @var array
+     * @var ArrayOfPhotoSize
      */
     protected $photo;
 
@@ -486,7 +486,7 @@ class Message extends BaseType implements TypeInterface
     }
 
     /**
-     * @return array
+     * @return ArrayOfPhotoSize
      */
     public function getNewChatPhoto()
     {
@@ -494,7 +494,7 @@ class Message extends BaseType implements TypeInterface
     }
 
     /**
-     * @param array $newChatPhoto
+     * @param ArrayOfPhotoSize $newChatPhoto
      */
     public function setNewChatPhoto($newChatPhoto)
     {
@@ -518,7 +518,7 @@ class Message extends BaseType implements TypeInterface
     }
 
     /**
-     * @return array
+     * @return ArrayOfPhotoSize
      */
     public function getPhoto()
     {
@@ -526,9 +526,9 @@ class Message extends BaseType implements TypeInterface
     }
 
     /**
-     * @param array $photo
+     * @param ArrayOfPhotoSize $photo
      */
-    public function setPhoto(array $photo)
+    public function setPhoto(ArrayOfPhotoSize $photo)
     {
         $this->photo = $photo;
     }


### PR DESCRIPTION
Got this while parsing telegram update:
PHP Fatal error:  Call to a member function toJson() on array in .../telegram-bot/api/src/BaseType.php on line 71

This commit fixed it. And ArrayOfPhotoSize still can be processed as array because it implements ArrayAccess and Iterator interfaces.