### PR TITLE
Add http_build_query for POST data

### DIFF
--- a/src/BotApi.php
+++ b/src/BotApi.php
@@ -204,7 +204,7 @@ class BotApi
 
         if ($data) {
             $options[CURLOPT_POST] = true;
-            $options[CURLOPT_POSTFIELDS] = $data;
+            $options[CURLOPT_POSTFIELDS] = http_build_query($data);
         }
 
         $response = self::jsonValidate($this->executeCurl($options), $this->returnArray);


### PR DESCRIPTION
Telegram channel starts with @ and cURL  interpret post values starts with @ as a file. I add http_build_query  to solve this problem.
