### PR TITLE
Process curl error and throw meaningful exception

### DIFF
--- a/src/BotApi.php
+++ b/src/BotApi.php
@@ -239,6 +239,9 @@ class BotApi
 
         $result = curl_exec($this->curl);
         self::curlValidate($this->curl);
+        if ($result === false) {
+            throw new HttpException(curl_error($this->curl), curl_errno($this->curl));
+        }
 
         return $result;
     }


### PR DESCRIPTION
Just had a situation when `curlValidate` didn't fire an exception after `curl_exec` returned plain `false`. Added a handling code with meaningful error message for that case.