### PR TITLE
Updated id to match is_numeric

### DIFF
--- a/src/Types/Chat.php
+++ b/src/Types/Chat.php
@@ -91,7 +91,6 @@ class Chat extends BaseType implements TypeInterface
         } else {
             throw new InvalidArgumentException();
         }
-
     }
 
     /**

--- a/src/Types/Chat.php
+++ b/src/Types/Chat.php
@@ -32,7 +32,7 @@ class Chat extends BaseType implements TypeInterface
     /**
      * Unique identifier for this chat, not exceeding 1e13 by absolute value
      *
-     * @var int
+     * @var int|double|float
      */
     protected $id;
 
@@ -86,7 +86,7 @@ class Chat extends BaseType implements TypeInterface
      */
     public function setId($id)
     {
-        if (is_integer($id) || is_float($id)) {
+        if (is_numeric($id)) {
             $this->id = $id;
         } else {
             throw new InvalidArgumentException();


### PR DESCRIPTION
I got an exception, because PHP casted the value to a double and not to
an integer or float

Closes TelegramBot/Api#41
