### PR TITLE
Checker always return true if omitted in TelegramBot\Api\Events\EventCollection::add

### DIFF
--- a/src/Events/EventCollection.php
+++ b/src/Events/EventCollection.php
@@ -48,6 +48,7 @@ class EventCollection
     {
         $this->events[] = !is_null($checker) ? new Event($event, $checker)
             : new Event($event, function () {
+                return true;
             });
 
         return $this;


### PR DESCRIPTION
Показалось логичным, что если не указывать `Checker` в `on`, то обработчик срабатывает на все сообщения. Так как нет смысла в обработчике который не реагирует вообще ни на что.