### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recen
 $ composer test
 ```
 
+Test on [RapidAPI](https://rapidapi.com/package/TelegramBot/functions?utm_source=TelegramGitHub&utm_medium=button)
+
 ## Contributing
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) for details.


### PR DESCRIPTION
I've added a link in your README to Telegram's functions page in RapidAPI. I've done this for a few Telegram SDKs to help those who are reading the READMEs, understand and test the API before use.