### PR TITLE
Add curl timeout 5 sec

### DIFF
--- a/src/BotApi.php
+++ b/src/BotApi.php
@@ -202,6 +202,7 @@ class BotApi
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_POST => null,
             CURLOPT_POSTFIELDS => null,
+            CURLOPT_TIMEOUT => 5,
         ];
 
         if ($data) {

--- a/src/Botan.php
+++ b/src/Botan.php
@@ -68,7 +68,8 @@ class Botan
             CURLOPT_HTTPHEADER => [
                 'Content-Type: application/json'
             ],
-            CURLOPT_POSTFIELDS => $message->toJson()
+            CURLOPT_POSTFIELDS => $message->toJson(),
+            CURLOPT_TIMEOUT => 5,
         ];
 
         curl_setopt_array($this->curl, $options);


### PR DESCRIPTION
In case Botan API does not work CURL waits too long, so the Telegram server is disconnected by timeout then sends the request again.