### PR TITLE
Fix `ArrayOfChatMemberEntity not found`

### DIFF
--- a/src/BotApi.php
+++ b/src/BotApi.php
@@ -4,6 +4,7 @@ namespace TelegramBot\Api;
 
 use TelegramBot\Api\Types\ArrayOfMessages;
 use TelegramBot\Api\Types\ArrayOfUpdates;
+use TelegramBot\Api\Types\ArrayOfChatMemberEntity;
 use TelegramBot\Api\Types\Chat;
 use TelegramBot\Api\Types\ChatMember;
 use TelegramBot\Api\Types\File;


### PR DESCRIPTION
Without fix, an error occurs "Class 'TelegramBot\Api\ArrayOfChatMemberEntity' not found" in getChatAdministrators 