### PR TITLE
bugfix maxCount in TelegramBot\Api\Collection\Collection

### DIFF
--- a/src/Collection/Collection.php
+++ b/src/Collection/Collection.php
@@ -28,7 +28,7 @@ class Collection
      */
     public function addItem(CollectionItemInterface $item, $key = null)
     {
-        if ($this->maxCount > 0 && $this->count() + 1 >= $this->maxCount) {
+        if ($this->maxCount > 0 && $this->count() >= $this->maxCount) {
             throw new ReachedMaxSizeException("Maximum collection items count reached. Max size: {$this->maxCount}");
         }
 

--- a/tests/Collection/CollectionTest.php
+++ b/tests/Collection/CollectionTest.php
@@ -67,7 +67,7 @@ class CollectionTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException(ReachedMaxSizeException::class);
         $media = new ArrayOfInputMedia();
         $media->setMaxCount(2);
-        for ($i = 1; $i < 3; $i++) {
+        for ($i = 0; $i < 3; $i++) {
             $media->addItem(new InputMediaPhoto('link'));
         }
     }


### PR DESCRIPTION
Collection allowed to add only `$maxCount-1` items instead of `$maxCount`
items.

also changed test `TelegramBot\Api\Test\Types\CollectionTest`.
case `can_not_add_more_then_max_limit` should `setMaxCount(2)`, do
`$media->addItem(...)` 3 times and check if it throws Exception, but:
```php
    for ($i = 1; $i < 3; $i++)
```
runs loop 2 times. Changed to:
```php
    for ($i = 0; $i < 3; $i++)
```