### PR TITLE
Fix #150

### DIFF
--- a/src/BotApi.php
+++ b/src/BotApi.php
@@ -221,7 +221,7 @@ class BotApi
         }
 
         if (!empty($this->customCurlOptions) && is_array($this->customCurlOptions)) {
-            $options += $this->customCurlOptions;
+            $options = $this->customCurlOptions + $options;
         }
 
         $response = self::jsonValidate($this->executeCurl($options), $this->returnArray);


### PR DESCRIPTION
При сложении массивов, если встречаются элементы с одинаковыми индексами, данные из первого массива не перезаписываются данными из второго. Отсюда вытекает проблема невозможности изменить некоторые элементы, к которым относится и TIMEOUT. Проблема легко решается перестановкой местами массивов.