### PR TITLE
update July 29, 2019 (Add type ChatPermissions)

### DIFF
--- a/src/Types/Chat.php
+++ b/src/Types/Chat.php
@@ -32,6 +32,7 @@ class Chat extends BaseType implements TypeInterface
         'description' => true,
         'invite_link' => true,
         'pinned_message' => Message::class,
+        'permissions' => ChatPermissions::class,
         'sticker_set_name' => true,
         'can_set_sticker_set' => true
     ];
@@ -107,6 +108,13 @@ class Chat extends BaseType implements TypeInterface
      * @var Message
      */
     protected $pinnedMessage;
+
+    /**
+     * Optional. Default chat member permissions, for groups and supergroups. Returned only in getChat.
+     *
+     * @var ChatPermissions
+     */
+    protected $permissions;
 
     /**
      * Optional. For supergroups, name of group sticker set. Returned only in getChat.
@@ -302,6 +310,22 @@ class Chat extends BaseType implements TypeInterface
     public function setPinnedMessage($pinnedMessage)
     {
         $this->pinnedMessage = $pinnedMessage;
+    }
+
+    /**
+     * @return ChatPermissions
+     */
+    public function getPermissions()
+    {
+        return $this->permissions;
+    }
+
+    /**
+     * @return ChatPermissions
+     */
+    public function setPermissions($permissions)
+    {
+        $this->permissions = $permissions;
     }
 
     /**

--- a/src/Types/ChatPermissions.php
+++ b/src/Types/ChatPermissions.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace TelegramBot\Api\Types;
+
+use TelegramBot\Api\BaseType;
+
+class ChatPermissions extends BaseType
+{
+
+    /**
+     * {@inheritdoc}
+     *
+     * @var array
+     */
+    static protected $map = [
+        'can_send_messages' => true,
+        'can_send_media_messages' => true,
+        'can_send_polls' => true,
+        'can_send_other_messages' => true,
+        'can_add_web_page_previews' => true,
+        'can_change_info' => true,
+        'can_invite_users' => true,
+        'can_pin_messages' => true
+    ];
+
+    /**
+     * Optional. True, if the user is allowed to send text messages, contacts, locations and venues
+     *
+     * @var bool
+     */
+    protected $canSendMessages;
+    
+    /**
+     * Optional. True, if the user is allowed to send audios, documents, photos, videos, video notes and voice notes, implies can_send_messages
+     *
+     * @var bool
+     */
+    protected $canSendMediaMessages;
+
+    /**
+     * Optional. True, if the user is allowed to send polls, implies can_send_messages
+     *
+     * @var bool
+     */
+    protected $canSendPolls;
+
+    /**
+     * Optional. True, if the user is allowed to send animations, games, stickers and use inline bots, implies can_send_media_messages
+     *
+     * @var bool
+     */
+    protected $canSendOtherMessages;
+
+    /**
+     * Optional. True, if the user is allowed to add web page previews to their messages, implies can_send_media_messages
+     *
+     * @var bool
+     */
+    protected $canAddWebPagePreviews;
+
+    /**
+     * Optional. True, if the user is allowed to change the chat title, photo and other settings. Ignored in public supergroups
+     *
+     * @var bool
+     */
+    protected $canChangeInfo;
+
+    /**
+     * Optional. True, if the user is allowed to invite new users to the chat
+     *
+     * @var bool
+     */
+    protected $canInviteUsers;
+
+    /**
+     * Optional. True, if the user is allowed to pin messages. Ignored in public supergroups
+     *
+     * @var bool
+     */
+    protected $canPinMessages;
+
+    /**
+     * @param bool $canSendMessages
+     */
+    public function setCanSendMessages($canSendMessages)
+    {
+        $this->canSendMessages = $canSendMessages;
+    }
+
+    /**
+     * @param bool $canSendMediaMessages
+     */
+    public function setCanSendMediaMessages($canSendMediaMessages)
+    {
+        $this->canSendMediaMessages = $canSendMediaMessages;
+    }
+
+    /**
+     * @param bool $canSendPolls
+     */
+    public function setCanSendPolls($canSendPolls)
+    {
+        $this->canSendPolls = $canSendPolls;
+    }
+
+    /**
+     * @param bool $canSendOtherMessages
+     */
+    public function setCanSendOtherMessages($canSendOtherMessages)
+    {
+        $this->canSendOtherMessages = $canSendOtherMessages;
+    }
+
+    /**
+     * @param bool $canAddWebPagePreviews
+     */
+    public function setCanAddWebPagePreviews($canAddWebPagePreviews)
+    {
+        $this->canAddWebPagePreviews = $canAddWebPagePreviews;
+    }
+
+    /**
+     * @param bool $canChangeInfo
+     */
+    public function setCanChangeInfo($canChangeInfo)
+    {
+        $this->canChangeInfo = $canChangeInfo;
+    }
+
+    /**
+     * @param bool $canInviteUsers
+     */
+    public function setCanInviteUsers($canInviteUsers)
+    {
+        $this->canInviteUsers = $canInviteUsers;
+    }
+
+    /**
+     * @param bool $canPinMessages
+     */
+    public function setCanPinMessages($canPinMessages)
+    {
+        $this->canPinMessages = $canPinMessages;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getCanSendMessages()
+    {
+        return $this->canSendMessages;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getCanSendMediaMessages()
+    {
+        return $this->canSendMediaMessages;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getCanSendPolls()
+    {
+        return $this->canSendPolls;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getCanSendOtherMessages()
+    {
+        return $this->canSendOtherMessages;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getCanAddWebPagePreviews()
+    {
+        return $this->canAddWebPagePreviews;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getCanChangeInfo()
+    {
+        return $this->canChangeInfo;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getCanInviteUsers()
+    {
+        return $this->canInviteUsers;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getCanPinMessages()
+    {
+        return $this->canPinMessages;
+    }
+}


### PR DESCRIPTION
Added support for default permissions in groups. New object ChatPermissions, containing actions which a member can take in a chat. New field permissions in the Chat object; new method setChatPermissions.

[https://core.telegram.org/bots/api#july-29-2019](https://core.telegram.org/bots/api#july-29-2019)