### PR TITLE
fix incorrect check answer from telegram

### DIFF
--- a/src/BotApi.php
+++ b/src/BotApi.php
@@ -227,7 +227,7 @@ class BotApi
         $response = self::jsonValidate($this->executeCurl($options), $this->returnArray);
 
         if ($this->returnArray) {
-            if (!isset($response['ok'])) {
+            if (!isset($response['ok']) || !$response['ok']) {
                 throw new Exception($response['description'], $response['error_code']);
             }
 


### PR DESCRIPTION
Answer from telegram may has a 'ok' field, but it may be equals to 'false'. If it is false, 'result' field doesn't exist.