### PR TITLE
Update Message type

### DIFF
--- a/src/Types/ArrayOfUser.php
+++ b/src/Types/ArrayOfUser.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TelegramBot\Api\Types;
+
+abstract class ArrayOfUser
+{
+    public static function fromResponse($data)
+    {
+        $arrayOfUsers = [];
+        foreach ($data as $user) {
+            $arrayOfUsers[] = User::fromResponse($user);
+        }
+
+        return $arrayOfUsers;
+    }
+}

--- a/src/Types/Dice.php
+++ b/src/Types/Dice.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace TelegramBot\Api\Types;
+
+use TelegramBot\Api\BaseType;
+use TelegramBot\Api\TypeInterface;
+
+/**
+ * Class Dice
+ * This object represents a dice with random value from 1 to 6. (Yes, we're aware of the “proper” singular of die.
+ * But it's awkward, and we decided to help it change. One dice at a time!)
+ */
+class Dice extends BaseType implements TypeInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @var array
+     */
+    static protected $requiredParams = ['value'];
+
+    /**
+     * {@inheritdoc}
+     *
+     * @var array
+     */
+    static protected $map = [
+        'value' => true
+    ];
+
+    /**
+     * Value of the dice, 1-6
+     *
+     * @var int
+     */
+    protected $value;
+
+    /**
+     * @return int
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param int $value
+     */
+    public function setValue($value)
+    {
+        $this->value = $value;
+    }
+}

--- a/src/Types/Message.php
+++ b/src/Types/Message.php
@@ -52,6 +52,7 @@ class Message extends BaseType implements TypeInterface
         'location' => Location::class,
         'venue' => Venue::class,
         'poll' => Poll::class,
+        'dice' => Dice::class,
         'new_chat_members' => ArrayOfUser::class,
         'left_chat_member' => User::class,
         'new_chat_title' => true,
@@ -279,6 +280,13 @@ class Message extends BaseType implements TypeInterface
      * @var \TelegramBot\Api\Types\Poll
      */
     protected $poll;
+
+    /**
+     * Optional. Message is a dice with random value from 1 to 6
+     *
+     * @var \TelegramBot\Api\Types\Dice
+     */
+    protected $dice;
 
     /**
      * Optional. New members that were added to the group or supergroup and information about them
@@ -876,6 +884,22 @@ class Message extends BaseType implements TypeInterface
     public function setPoll($poll)
     {
         $this->poll = $poll;
+    }
+
+    /**
+     * @return Dice
+     */
+    public function getDice()
+    {
+        return $this->dice;
+    }
+
+    /**
+     * @param Dice $dice
+     */
+    public function setDice(Dice $dice)
+    {
+        $this->dice = $dice;
     }
 
     /**

--- a/src/Types/Message.php
+++ b/src/Types/Message.php
@@ -4,6 +4,7 @@ namespace TelegramBot\Api\Types;
 use TelegramBot\Api\BaseType;
 use TelegramBot\Api\InvalidArgumentException;
 use TelegramBot\Api\TypeInterface;
+use TelegramBot\Api\Types\Inline\InlineKeyboardMarkup;
 use TelegramBot\Api\Types\Payments\Invoice;
 use TelegramBot\Api\Types\Payments\SuccessfulPayment;
 
@@ -30,24 +31,28 @@ class Message extends BaseType implements TypeInterface
         'forward_from_chat' => Chat::class,
         'forward_from_message_id' => true,
         'forward_date' => true,
+        'forward_signature' => true,
+        'forward_sender_name' => true,
         'reply_to_message' => Message::class,
+        'edit_date' => true,
+        'media_group_id' => true,
+        'author_signature' => true,
         'text' => true,
         'entities' => ArrayOfMessageEntity::class,
         'caption_entities' => ArrayOfMessageEntity::class,
         'audio' => Audio::class,
         'document' => Document::class,
+        'animation' => Animation::class,
         'photo' => ArrayOfPhotoSize::class,
-        'media_group_id' => true,
         'sticker' => Sticker::class,
         'video' => Video::class,
-        'animation' => Animation::class,
         'voice' => Voice::class,
         'caption' => true,
         'contact' => Contact::class,
         'location' => Location::class,
         'venue' => Venue::class,
         'poll' => Poll::class,
-        'new_chat_member' => User::class,
+        'new_chat_members' => ArrayOfUser::class,
         'left_chat_member' => User::class,
         'new_chat_title' => true,
         'new_chat_photo' => ArrayOfPhotoSize::class,
@@ -60,9 +65,8 @@ class Message extends BaseType implements TypeInterface
         'pinned_message' => Message::class,
         'invoice' => Invoice::class,
         'successful_payment' => SuccessfulPayment::class,
-        'forward_signature' => true,
-        'author_signature' => true,
-        'connected_website' => true
+        'connected_website' => true,
+        'reply_markup' => InlineKeyboardMarkup::class,
     ];
 
     /**
@@ -117,6 +121,21 @@ class Message extends BaseType implements TypeInterface
     protected $forwardFromMessageId;
 
     /**
+     * Optional. For messages forwarded from channels, signature of the post author if present
+     *
+     * @var string
+     */
+    protected $forwardSignature;
+
+    /**
+     * Optional. Sender's name for messages forwarded from users who disallow adding a link to their account
+     * in forwarded messages
+     *
+     * @var string
+     */
+    protected $forwardSenderName;
+
+    /**
      * Optional. For forwarded messages, date the original message was sent in Unix time
      *
      * @var int
@@ -130,6 +149,28 @@ class Message extends BaseType implements TypeInterface
      * @var \TelegramBot\Api\Types\Message
      */
     protected $replyToMessage;
+
+    /**
+     * Optional. Date the message was last edited in Unix time
+     *
+     * @var int
+     */
+    protected $editDate;
+
+    /**
+     * Optional. The unique identifier of a media message group
+     * this message belongs to
+     *
+     * @var int
+     */
+    protected $mediaGroupId;
+
+    /**
+     * Optional. Signature of the post author for messages in channels
+     *
+     * @var string
+     */
+    protected $authorSignature;
 
     /**
      * Optional. For text messages, the actual UTF-8 text of the message
@@ -147,6 +188,14 @@ class Message extends BaseType implements TypeInterface
     protected $entities;
 
     /**
+     * Optional. For messages with a caption, special entities like usernames,
+     * URLs, bot commands, etc. that appear in the caption
+     *
+     * @var ArrayOfMessageEntity
+     */
+    protected $captionEntities;
+
+    /**
      * Optional. Message is an audio file, information about the file
      *
      * @var \TelegramBot\Api\Types\Audio
@@ -161,20 +210,19 @@ class Message extends BaseType implements TypeInterface
     protected $document;
 
     /**
+     * Optional. Message is a animation, information about the animation
+     *
+     * @var \TelegramBot\Api\Types\Animation
+     */
+    protected $animation;
+
+    /**
      * Optional. Message is a photo, available sizes of the photo
      * array of \TelegramBot\Api\Types\Photo
      *
      * @var array
      */
     protected $photo;
-
-    /**
-     * Optional. The unique identifier of a media message group
-     * this message belongs to
-     *
-     * @var int
-     */
-    protected $mediaGroupId;
 
     /**
      * Optional. Message is a sticker, information about the sticker
@@ -189,13 +237,6 @@ class Message extends BaseType implements TypeInterface
      * @var \TelegramBot\Api\Types\Video
      */
     protected $video;
-    
-    /**
-     * Optional. Message is a animation, information about the animation
-     *
-     * @var \TelegramBot\Api\Types\Animation
-     */
-    protected $animation;
 
     /**
      * Optional. Message is a voice message, information about the file
@@ -203,6 +244,13 @@ class Message extends BaseType implements TypeInterface
      * @var \TelegramBot\Api\Types\Voice
      */
     protected $voice;
+
+    /**
+     * Optional. Text description of the video (usually empty)
+     *
+     * @var string
+     */
+    protected $caption;
 
     /**
      * Optional. Message is a shared contact, information about the contact
@@ -233,11 +281,13 @@ class Message extends BaseType implements TypeInterface
     protected $poll;
 
     /**
-     * Optional. A new member was added to the group, information about them (this member may be bot itself)
+     * Optional. New members that were added to the group or supergroup and information about them
+     * (the bot itself may be one of these members)
+     * array of \TelegramBot\Api\Types\User
      *
-     * @var \TelegramBot\Api\Types\User
+     * @var array
      */
-    protected $newChatMember;
+    protected $newChatMembers;
 
     /**
      * Optional. A member was removed from the group, information about them (this member may be bot itself)
@@ -273,14 +323,6 @@ class Message extends BaseType implements TypeInterface
      * @var bool
      */
     protected $groupChatCreated;
-
-    /**
-     * Optional. Text description of the video (usually empty)
-     *
-     * @var string
-     */
-    protected $caption;
-
 
     /**
      * Optional. Service message: the supergroup has been created
@@ -335,28 +377,6 @@ class Message extends BaseType implements TypeInterface
     protected $successfulPayment;
 
     /**
-     * Optional. For messages forwarded from channels, signature of the post author if present
-     *
-     * @var string
-     */
-    protected $forwardSignature;
-
-    /**
-     * Optional. Signature of the post author for messages in channels
-     *
-     * @var string
-     */
-    protected $authorSignature;
-
-    /**
-     * Optional. For messages with a caption, special entities like usernames,
-     * URLs, bot commands, etc. that appear in the caption
-     *
-     * @var ArrayOfMessageEntity
-     */
-    protected $captionEntities;
-
-    /**
      * Optional. The domain name of the website on which the user has logged in.
      *
      * @var string
@@ -364,35 +384,48 @@ class Message extends BaseType implements TypeInterface
     protected $connectedWebsite;
 
     /**
-     * @return string
+     * Optional. Inline keyboard attached to the message. login_url buttons are represented as ordinary url buttons.
+     *
+     * @var InlineKeyboardMarkup
      */
-    public function getCaption()
+    protected $replyMarkup;
+
+    /**
+     * @return int
+     */
+    public function getMessageId()
     {
-        return $this->caption;
+        return $this->messageId;
     }
 
     /**
-     * @param string $caption
+     * @param int $messageId
+     *
+     * @throws InvalidArgumentException
      */
-    public function setCaption($caption)
+    public function setMessageId($messageId)
     {
-        $this->caption = $caption;
+        if (is_integer($messageId) || is_float($messageId)) {
+            $this->messageId = $messageId;
+        } else {
+            throw new InvalidArgumentException();
+        }
     }
 
     /**
-     * @return Audio
+     * @return User
      */
-    public function getAudio()
+    public function getFrom()
     {
-        return $this->audio;
+        return $this->from;
     }
 
     /**
-     * @param Audio $audio
+     * @param User $from
      */
-    public function setAudio(Audio $audio)
+    public function setFrom(User $from)
     {
-        $this->audio = $audio;
+        $this->from = $from;
     }
 
     /**
@@ -412,22 +445,6 @@ class Message extends BaseType implements TypeInterface
     }
 
     /**
-     * @return Contact
-     */
-    public function getContact()
-    {
-        return $this->contact;
-    }
-
-    /**
-     * @param Contact $contact
-     */
-    public function setContact(Contact $contact)
-    {
-        $this->contact = $contact;
-    }
-
-    /**
      * @return int
      */
     public function getDate()
@@ -442,62 +459,8 @@ class Message extends BaseType implements TypeInterface
      */
     public function setDate($date)
     {
-        if (is_integer($date)) {
+        if (is_int($date)) {
             $this->date = $date;
-        } else {
-            throw new InvalidArgumentException();
-        }
-    }
-
-    /**
-     * @return boolean
-     */
-    public function isDeleteChatPhoto()
-    {
-        return $this->deleteChatPhoto;
-    }
-
-    /**
-     * @param boolean $deleteChatPhoto
-     */
-    public function setDeleteChatPhoto($deleteChatPhoto)
-    {
-        $this->deleteChatPhoto = (bool)$deleteChatPhoto;
-    }
-
-    /**
-     * @return Document
-     */
-    public function getDocument()
-    {
-        return $this->document;
-    }
-
-    /**
-     * @param Document $document
-     */
-    public function setDocument($document)
-    {
-        $this->document = $document;
-    }
-
-    /**
-     * @return int
-     */
-    public function getForwardDate()
-    {
-        return $this->forwardDate;
-    }
-
-    /**
-     * @param int $forwardDate
-     *
-     * @throws InvalidArgumentException
-     */
-    public function setForwardDate($forwardDate)
-    {
-        if (is_integer($forwardDate)) {
-            $this->forwardDate = $forwardDate;
         } else {
             throw new InvalidArgumentException();
         }
@@ -552,35 +515,319 @@ class Message extends BaseType implements TypeInterface
     }
 
     /**
-     * @return boolean
+     * @return string
      */
-    public function isGroupChatCreated()
+    public function getForwardSignature()
     {
-        return $this->groupChatCreated;
+        return $this->forwardSignature;
     }
 
     /**
-     * @param boolean $groupChatCreated
+     * @param string $forwardSignature
      */
-    public function setGroupChatCreated($groupChatCreated)
+    public function setForwardSignature($forwardSignature)
     {
-        $this->groupChatCreated = (bool)$groupChatCreated;
+        $this->forwardSignature = $forwardSignature;
     }
 
     /**
-     * @return User
+     * @return string
      */
-    public function getLeftChatMember()
+    public function getForwardSenderName()
     {
-        return $this->leftChatMember;
+        return $this->forwardSenderName;
     }
 
     /**
-     * @param User $leftChatMember
+     * @param string $forwardSenderName
      */
-    public function setLeftChatMember($leftChatMember)
+    public function setForwardSenderName($forwardSenderName)
     {
-        $this->leftChatMember = $leftChatMember;
+        $this->forwardSenderName = $forwardSenderName;
+    }
+
+    /**
+     * @return int
+     */
+    public function getForwardDate()
+    {
+        return $this->forwardDate;
+    }
+
+    /**
+     * @param int $forwardDate
+     *
+     * @throws InvalidArgumentException
+     */
+    public function setForwardDate($forwardDate)
+    {
+        if (is_int($forwardDate)) {
+            $this->forwardDate = $forwardDate;
+        } else {
+            throw new InvalidArgumentException();
+        }
+    }
+
+    /**
+     * @return Message
+     */
+    public function getReplyToMessage()
+    {
+        return $this->replyToMessage;
+    }
+
+    /**
+     * @param Message $replyToMessage
+     */
+    public function setReplyToMessage(Message $replyToMessage)
+    {
+        $this->replyToMessage = $replyToMessage;
+    }
+
+    /**
+     * @return int
+     */
+    public function getEditDate()
+    {
+        return $this->editDate;
+    }
+
+    /**
+     * @param int $editDate
+     *
+     * @throws InvalidArgumentException
+     */
+    public function setEditDate($editDate)
+    {
+        if (is_int($editDate)) {
+            $this->editDate = $editDate;
+        } else {
+            throw new InvalidArgumentException();
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getMediaGroupId()
+    {
+        return $this->mediaGroupId;
+    }
+
+    /**
+     * @param int $mediaGroupId
+     */
+    public function setMediaGroupId($mediaGroupId)
+    {
+        $this->mediaGroupId = $mediaGroupId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getAuthorSignature()
+    {
+        return $this->authorSignature;
+    }
+
+    /**
+     * @param string $authorSignature
+     */
+    public function setAuthorSignature($authorSignature)
+    {
+        $this->authorSignature = $authorSignature;
+    }
+
+    /**
+     * @return string
+     */
+    public function getText()
+    {
+        return $this->text;
+    }
+
+    /**
+     * @param string $text
+     */
+    public function setText($text)
+    {
+        $this->text = $text;
+    }
+
+    /**
+     * @return array
+     */
+    public function getEntities()
+    {
+        return $this->entities;
+    }
+
+    /**
+     * @param array $entities
+     */
+    public function setEntities($entities)
+    {
+        $this->entities = $entities;
+    }
+
+    /**
+     * @return ArrayOfMessageEntity
+     */
+    public function getCaptionEntities()
+    {
+        return $this->captionEntities;
+    }
+
+    /**
+     * @param ArrayOfMessageEntity $captionEntities
+     */
+    public function setCaptionEntities($captionEntities)
+    {
+        $this->captionEntities = $captionEntities;
+    }
+
+    /**
+     * @return Audio
+     */
+    public function getAudio()
+    {
+        return $this->audio;
+    }
+
+    /**
+     * @param Audio $audio
+     */
+    public function setAudio(Audio $audio)
+    {
+        $this->audio = $audio;
+    }
+
+    /**
+     * @return Document
+     */
+    public function getDocument()
+    {
+        return $this->document;
+    }
+
+    /**
+     * @param Document $document
+     */
+    public function setDocument($document)
+    {
+        $this->document = $document;
+    }
+
+    /**
+     * @return Animation
+     */
+    public function getAnimation()
+    {
+        return $this->animation;
+    }
+
+    /**
+     * @param Animation $animation
+     */
+    public function setAnimation(Animation $animation)
+    {
+        $this->animation = $animation;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPhoto()
+    {
+        return $this->photo;
+    }
+
+    /**
+     * @param array $photo
+     */
+    public function setPhoto(array $photo)
+    {
+        $this->photo = $photo;
+    }
+
+    /**
+     * @return Sticker
+     */
+    public function getSticker()
+    {
+        return $this->sticker;
+    }
+
+    /**
+     * @param Sticker $sticker
+     */
+    public function setSticker(Sticker $sticker)
+    {
+        $this->sticker = $sticker;
+    }
+
+    /**
+     * @return Video
+     */
+    public function getVideo()
+    {
+        return $this->video;
+    }
+
+    /**
+     * @param Video $video
+     */
+    public function setVideo(Video $video)
+    {
+        $this->video = $video;
+    }
+
+    /**
+     * @return Voice
+     */
+    public function getVoice()
+    {
+        return $this->voice;
+    }
+
+    /**
+     * @param Voice $voice
+     */
+    public function setVoice($voice)
+    {
+        $this->voice = $voice;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCaption()
+    {
+        return $this->caption;
+    }
+
+    /**
+     * @param string $caption
+     */
+    public function setCaption($caption)
+    {
+        $this->caption = $caption;
+    }
+
+    /**
+     * @return Contact
+     */
+    public function getContact()
+    {
+        return $this->contact;
+    }
+
+    /**
+     * @param Contact $contact
+     */
+    public function setContact(Contact $contact)
+    {
+        $this->contact = $contact;
     }
 
     /**
@@ -632,57 +879,35 @@ class Message extends BaseType implements TypeInterface
     }
 
     /**
-     * @return int
+     * @return array
      */
-    public function getMessageId()
+    public function getNewChatMembers()
     {
-        return $this->messageId;
+        return $this->newChatMembers;
     }
 
     /**
-     * @param int $messageId
-     *
-     * @throws InvalidArgumentException
+     * @param array $newChatMembers
      */
-    public function setMessageId($messageId)
+    public function setNewChatMembers($newChatMembers)
     {
-        if (is_integer($messageId) || is_float($messageId)) {
-            $this->messageId = $messageId;
-        } else {
-            throw new InvalidArgumentException();
-        }
+        $this->newChatMembers = $newChatMembers;
     }
 
     /**
      * @return User
      */
-    public function getNewChatMember()
+    public function getLeftChatMember()
     {
-        return $this->newChatMember;
+        return $this->leftChatMember;
     }
 
     /**
-     * @param User $newChatMember
+     * @param User $leftChatMember
      */
-    public function setNewChatMember($newChatMember)
+    public function setLeftChatMember($leftChatMember)
     {
-        $this->newChatMember = $newChatMember;
-    }
-
-    /**
-     * @return array
-     */
-    public function getNewChatPhoto()
-    {
-        return $this->newChatPhoto;
-    }
-
-    /**
-     * @param array $newChatPhoto
-     */
-    public function setNewChatPhoto($newChatPhoto)
-    {
-        $this->newChatPhoto = $newChatPhoto;
+        $this->leftChatMember = $leftChatMember;
     }
 
     /**
@@ -704,161 +929,57 @@ class Message extends BaseType implements TypeInterface
     /**
      * @return array
      */
-    public function getPhoto()
+    public function getNewChatPhoto()
     {
-        return $this->photo;
+        return $this->newChatPhoto;
     }
 
     /**
-     * @param array $photo
+     * @param array $newChatPhoto
      */
-    public function setPhoto(array $photo)
+    public function setNewChatPhoto($newChatPhoto)
     {
-        $this->photo = $photo;
+        $this->newChatPhoto = $newChatPhoto;
     }
 
     /**
-     * @return int
+     * @return boolean
      */
-    public function getMediaGroupId()
+    public function isDeleteChatPhoto()
     {
-        return $this->mediaGroupId;
+        return $this->deleteChatPhoto;
     }
 
     /**
-     * @param int $mediaGroupId
+     * @param boolean $deleteChatPhoto
      */
-    public function setMediaGroupId($mediaGroupId)
+    public function setDeleteChatPhoto($deleteChatPhoto)
     {
-        $this->mediaGroupId = $mediaGroupId;
+        $this->deleteChatPhoto = (bool)$deleteChatPhoto;
     }
 
     /**
-     * @return Message
+     * @return boolean
      */
-    public function getReplyToMessage()
+    public function isGroupChatCreated()
     {
-        return $this->replyToMessage;
+        return $this->groupChatCreated;
     }
 
     /**
-     * @param Message $replyToMessage
+     * @param boolean $groupChatCreated
      */
-    public function setReplyToMessage(Message $replyToMessage)
+    public function setGroupChatCreated($groupChatCreated)
     {
-        $this->replyToMessage = $replyToMessage;
+        $this->groupChatCreated = (bool)$groupChatCreated;
     }
 
     /**
-     * @return Sticker
+     * @return boolean
      */
-    public function getSticker()
+    public function isSupergroupChatCreated()
     {
-        return $this->sticker;
-    }
-
-    /**
-     * @param Sticker $sticker
-     */
-    public function setSticker(Sticker $sticker)
-    {
-        $this->sticker = $sticker;
-    }
-
-    /**
-     * @return string
-     */
-    public function getText()
-    {
-        return $this->text;
-    }
-
-    /**
-     * @param string $text
-     */
-    public function setText($text)
-    {
-        $this->text = $text;
-    }
-
-    /**
-     * @return array
-     */
-    public function getEntities()
-    {
-        return $this->entities;
-    }
-
-    /**
-     * @param array $entities
-     */
-    public function setEntities($entities)
-    {
-        $this->entities = $entities;
-    }
-
-    /**
-     * @return User
-     */
-    public function getFrom()
-    {
-        return $this->from;
-    }
-
-    /**
-     * @param User $from
-     */
-    public function setFrom(User $from)
-    {
-        $this->from = $from;
-    }
-
-    /**
-     * @return Video
-     */
-    public function getVideo()
-    {
-        return $this->video;
-    }
-
-    /**
-     * @param Video $video
-     */
-    public function setVideo(Video $video)
-    {
-        $this->video = $video;
-    }
-    
-    /**
-     * @return Animation
-     */
-    public function getAnimation()
-    {
-        return $this->animation;
-    }
-
-    /**
-     * @param Animation $animation
-     */
-    public function setAnimation(Animation $animation)
-    {
-        $this->animation = $animation;
-    }
-
-    /**
-     * @return Voice
-     */
-    public function getVoice()
-    {
-        return $this->voice;
-    }
-
-    /**
-     * @param Voice $voice
-     */
-    public function setVoice($voice)
-    {
-        $this->voice = $voice;
+        return $this->supergroupChatCreated;
     }
 
     /**
@@ -872,9 +993,9 @@ class Message extends BaseType implements TypeInterface
     /**
      * @return boolean
      */
-    public function isSupergroupChatCreated()
+    public function isChannelChatCreated()
     {
-        return $this->supergroupChatCreated;
+        return $this->channelChatCreated;
     }
 
     /**
@@ -886,11 +1007,11 @@ class Message extends BaseType implements TypeInterface
     }
 
     /**
-     * @return boolean
+     * @return int
      */
-    public function isChannelChatCreated()
+    public function getMigrateToChatId()
     {
-        return $this->channelChatCreated;
+        return $this->migrateToChatId;
     }
 
     /**
@@ -904,9 +1025,9 @@ class Message extends BaseType implements TypeInterface
     /**
      * @return int
      */
-    public function getMigrateToChatId()
+    public function getMigrateFromChatId()
     {
-        return $this->migrateToChatId;
+        return $this->migrateFromChatId;
     }
 
     /**
@@ -915,14 +1036,6 @@ class Message extends BaseType implements TypeInterface
     public function setMigrateFromChatId($migrateFromChatId)
     {
         $this->migrateFromChatId = $migrateFromChatId;
-    }
-
-    /**
-     * @return int
-     */
-    public function getMigrateFromChatId()
-    {
-        return $this->migrateFromChatId;
     }
 
     /**
@@ -980,54 +1093,6 @@ class Message extends BaseType implements TypeInterface
     /**
      * @return string
      */
-    public function getForwardSignature()
-    {
-        return $this->forwardSignature;
-    }
-
-    /**
-     * @param string $forwardSignature
-     */
-    public function setForwardSignature($forwardSignature)
-    {
-        $this->forwardSignature = $forwardSignature;
-    }
-
-    /**
-     * @return string
-     */
-    public function getAuthorSignature()
-    {
-        return $this->authorSignature;
-    }
-
-    /**
-     * @param string $authorSignature
-     */
-    public function setAuthorSignature($authorSignature)
-    {
-        $this->authorSignature = $authorSignature;
-    }
-
-    /**
-     * @return ArrayOfMessageEntity
-     */
-    public function getCaptionEntities()
-    {
-        return $this->captionEntities;
-    }
-
-    /**
-     * @param ArrayOfMessageEntity $captionEntities
-     */
-    public function setCaptionEntities($captionEntities)
-    {
-        $this->captionEntities = $captionEntities;
-    }
-
-    /**
-     * @return string
-     */
     public function getConnectedWebsite()
     {
         return $this->connectedWebsite;
@@ -1039,5 +1104,21 @@ class Message extends BaseType implements TypeInterface
     public function setConnectedWebsite($connectedWebsite)
     {
         $this->connectedWebsite = $connectedWebsite;
+    }
+
+    /**
+     * @return InlineKeyboardMarkup
+     */
+    public function getReplyMarkup()
+    {
+        return $this->replyMarkup;
+    }
+
+    /**
+     * @param InlineKeyboardMarkup $replyMarkup
+     */
+    public function setReplyMarkup($replyMarkup)
+    {
+        $this->replyMarkup = $replyMarkup;
     }
 }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -479,10 +479,10 @@ class MessageTest extends \PHPUnit_Framework_TestCase
             'last_name' => 'Gusev',
             'username' => 'iGusev'
         ));
-        $item->setNewChatMember($user);
+        $item->setNewChatMembers([$user]);
 
 
-        $this->assertAttributeEquals($user, 'newChatMember', $item);
+        $this->assertAttributeEquals([$user], 'newChatMembers', $item);
     }
 
     public function testGetNewChatParticipant()
@@ -494,10 +494,10 @@ class MessageTest extends \PHPUnit_Framework_TestCase
             'last_name' => 'Gusev',
             'username' => 'iGusev'
         ));
-        $item->setNewChatMember($user);
+        $item->setNewChatMembers([$user]);
 
-        $this->assertEquals($user, $item->getNewChatMember());
-        $this->assertInstanceOf('\TelegramBot\Api\Types\User', $item->getNewChatMember());
+        $this->assertEquals([$user], $item->getNewChatMembers());
+        $this->assertInstanceOf('\TelegramBot\Api\Types\User', $item->getNewChatMembers()[0]);
     }
 
     public function testSetNewChatTitle()


### PR DESCRIPTION
### Updates
1. Added missing fields: `edit_date`, `forward_sender_name`, `dice`, `reply_markup`.
2. Added `ArrayOfUser` type.
3. Added `Dice` type.
4. `new_chat_member` field is renamed to `new_chat_members` and calls `ArrayOfUser` type.
5. All fields and getters / setters are sorted like in Telegram documentation.