### PR TITLE
Add support VideoNote type.

### DIFF
--- a/src/Types/Message.php
+++ b/src/Types/Message.php
@@ -46,6 +46,7 @@ class Message extends BaseType implements TypeInterface
         'photo' => ArrayOfPhotoSize::class,
         'sticker' => Sticker::class,
         'video' => Video::class,
+        'video_note' => VideoNote::class,
         'voice' => Voice::class,
         'caption' => true,
         'contact' => Contact::class,
@@ -237,6 +238,13 @@ class Message extends BaseType implements TypeInterface
      * @var \TelegramBot\Api\Types\Video
      */
     protected $video;
+
+    /**
+     * Optional. Message is a video note, information about the video note
+     *
+     * @var \TelegramBot\Api\Types\VideoNote
+     */
+    protected $videoNote;
 
     /**
      * Optional. Message is a voice message, information about the file
@@ -787,6 +795,23 @@ class Message extends BaseType implements TypeInterface
     public function setVideo(Video $video)
     {
         $this->video = $video;
+    }
+
+
+    /**
+     * @return VideoNote
+     */
+    public function getVideoNote()
+    {
+        return $this->videoNote;
+    }
+
+    /**
+     * @param VideoNote $videoNote
+     */
+    public function setVideoNote(VideoNote $videoNote)
+    {
+        $this->videoNote = $videoNote;
     }
 
     /**

--- a/src/Types/VideoNote.php
+++ b/src/Types/VideoNote.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace TelegramBot\Api\Types;
+
+use TelegramBot\Api\BaseType;
+use TelegramBot\Api\InvalidArgumentException;
+use TelegramBot\Api\TypeInterface;
+
+/**
+ * Class Video
+ * This object represents a video file.
+ *
+ * @package TelegramBot\Api\Types
+ */
+class VideoNote extends BaseType implements TypeInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @var array
+     */
+    static protected $requiredParams = ['file_id', 'length', 'duration'];
+
+    /**
+     * {@inheritdoc}
+     *
+     * @var array
+     */
+    static protected $map = [
+        'file_id' => true,
+        'length' => true,
+        'duration' => true,
+        'thumb' => PhotoSize::class,
+        'file_size' => true
+    ];
+
+    /**
+     * Unique identifier for this file
+     *
+     * @var string
+     */
+    protected $fileId;
+
+    /**
+     * Duration of the video note in seconds as defined by sender
+     *
+     * @var int
+     */
+    protected $duration;
+
+    /**
+     * Value of video width and height (diameter of the video message) as defined by sender
+     *
+     * @var int
+     */
+    protected $length;
+
+    /**
+     * Video Note thumbnail
+     *
+     * @var PhotoSize
+     */
+    protected $thumb;
+
+
+    /**
+     * Optional. File size
+     *
+     * @var int
+     */
+    protected $fileSize;
+
+    /**
+     * @return int
+     */
+    public function getDuration()
+    {
+        return $this->duration;
+    }
+
+    /**
+     * @param int $duration
+     *
+     * @throws InvalidArgumentException
+     */
+    public function setDuration($duration)
+    {
+        if (is_integer($duration)) {
+            $this->duration = $duration;
+        } else {
+            throw new InvalidArgumentException();
+        }
+    }
+
+    /**
+     * @return string
+     */
+    public function getFileId()
+    {
+        return $this->fileId;
+    }
+
+    /**
+     * @param string $fileId
+     */
+    public function setFileId($fileId)
+    {
+        $this->fileId = $fileId;
+    }
+
+    /**
+     * @return int
+     */
+    public function getFileSize()
+    {
+        return $this->fileSize;
+    }
+
+    /**
+     * @param int $fileSize
+     *
+     * @throws InvalidArgumentException
+     */
+    public function setFileSize($fileSize)
+    {
+        if (is_integer($fileSize)) {
+            $this->fileSize = $fileSize;
+        } else {
+            throw new InvalidArgumentException();
+        }
+    }
+
+    /**
+     * @return int
+     */
+    public function getLength()
+    {
+        return $this->length;
+    }
+
+    /**
+     * @param int $length
+     *
+     * @throws InvalidArgumentException
+     */
+    public function setLength($length)
+    {
+        if (is_integer($length)) {
+            $this->length = $length;
+        } else {
+            throw new InvalidArgumentException();
+        }
+    }
+
+    /**
+     * @return PhotoSize
+     */
+    public function getThumb()
+    {
+        return $this->thumb;
+    }
+
+    /**
+     * @param PhotoSize $thumb
+     */
+    public function setThumb(PhotoSize $thumb)
+    {
+        $this->thumb = $thumb;
+    }
+
+}


### PR DESCRIPTION
Support for VideoNote Object. This object represents a video message (available in Telegram apps as of v.4.0).
https://core.telegram.org/bots/api#videonote