### PR TITLE
Bot API 5.1, Added two new update types

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -94,6 +94,14 @@ class Client
         return $this->on(self::getPreCheckoutQueryEvent($action), self::getPreCheckoutQueryChecker());
     }
 
+    public function myChatMember(Closure $action) {
+        return $this->on(self::getMyChatMemberEvent($action), self::getMyChatMemberChecker());
+    }
+
+    public function chatMember(Closure $action) {
+        return $this->on(self::getChatMemberEvent($action), self::getChatMemberChecker());
+    }
+
     /**
      * Use this method to add an event.
      * If second closure will return true (or if you are passed null instead of closure), first one will be executed.
@@ -280,6 +288,30 @@ class Client
         };
     }
 
+    protected static function getMyChatMemberEvent(Closure $action) {
+        return function (Update $update) use ($action) {
+            if (!$update->getMyChatMember()) {
+                return true;
+            }
+
+            $reflectionAction = new ReflectionFunction($action);
+            $reflectionAction->invokeArgs([$update->getMyChatMember()]);
+            return false;
+        };
+    }
+
+    protected static function getChatMemberEvent(Closure $action) {
+        return function (Update $update) use ($action) {
+            if (!$update->getChatMember()) {
+                return true;
+            }
+
+            $reflectionAction = new ReflectionFunction($action);
+            $reflectionAction->invokeArgs([$update->getChatMember()]);
+            return false;
+        };
+    }
+
     /**
      * Returns check function to handling the command.
      *
@@ -394,6 +426,28 @@ class Client
     {
         return function (Update $update) {
             return !is_null($update->getPreCheckoutQuery());
+        };
+    }
+
+    /**
+     * Returns check function to handling the myChatMember updates.
+     *
+     * @return Closure
+     */
+    public static function getMyChatMemberChecker() {
+        return function (Update $update) {
+            return !is_null($update->getMyChatMember());
+        };
+    }
+
+    /**
+     * Returns check function to handling the chatMember updates.
+     *
+     * @return Closure
+     */
+    public static function getChatMemberChecker() {
+        return function (Update $update) {
+            return !is_null($update->getChatMember());
         };
     }
 

--- a/src/Types/ChatInviteLink.php
+++ b/src/Types/ChatInviteLink.php
@@ -1,0 +1,175 @@
+<?php
+
+
+namespace TelegramBot\Api\Types;
+
+
+use TelegramBot\Api\BaseType;
+
+class ChatInviteLink extends BaseType
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @var array
+     */
+    protected static $requiredParams = [
+        'invite_link',
+        'creator',
+        'is_primary',
+        'is_revoked',
+    ];
+
+    /**
+     * {@inheritdoc}
+     *
+     * @var array
+     */
+    protected static $map = [
+        'invite_link' => true,
+        'creator' => User::class,
+        'is_primary' => true,
+        'is_revoked' => true,
+        'expire_date' => true,
+        'member_limit' => true
+    ];
+
+    /**
+     * The invite link. If the link was created by another chat administrator,
+     * then the second part of the link will be replaced with “…”.
+     *
+     * @var string
+     */
+    protected $invite_link;
+
+    /**
+     * Creator of the link
+     *
+     * @var User
+     */
+    protected $creator;
+
+    /**
+     * True, if the link is primary
+     *
+     * @var boolean
+     */
+    protected $isPrimary;
+
+    /**
+     * True, if the link is revoked
+     *
+     * @var boolean
+     */
+    protected $isRevoked;
+
+    /**
+     * Optional. Point in time (Unix timestamp) when the link will expire or has been expired
+     *
+     * @var int
+     */
+    protected $expireDate;
+
+    /**
+     * Optional. Maximum number of users that can be members of the chat simultaneously after joining the chat via this invite link; 1-99999
+     *
+     * @var int
+     */
+    protected $memberLimit;
+
+    /**
+     * @return string
+     */
+    public function getInviteLink()
+    {
+        return $this->invite_link;
+    }
+
+    /**
+     * @param string $invite_link
+     */
+    public function setInviteLink($invite_link)
+    {
+        $this->invite_link = $invite_link;
+    }
+
+    /**
+     * @return User
+     */
+    public function getCreator()
+    {
+        return $this->creator;
+    }
+
+    /**
+     * @param User $creator
+     */
+    public function setCreator($creator)
+    {
+        $this->creator = $creator;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isPrimary()
+    {
+        return $this->isPrimary;
+    }
+
+    /**
+     * @param bool $isPrimary
+     */
+    public function setIsPrimary($isPrimary)
+    {
+        $this->isPrimary = $isPrimary;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isRevoked()
+    {
+        return $this->isRevoked;
+    }
+
+    /**
+     * @param bool $isRevoked
+     */
+    public function setIsRevoked($isRevoked)
+    {
+        $this->isRevoked = $isRevoked;
+    }
+
+    /**
+     * @return int
+     */
+    public function getExpireDate()
+    {
+        return $this->expireDate;
+    }
+
+    /**
+     * @param int $expireDate
+     */
+    public function setExpireDate($expireDate)
+    {
+        $this->expireDate = $expireDate;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMemberLimit()
+    {
+        return $this->memberLimit;
+    }
+
+    /**
+     * @param int $memberLimit
+     */
+    public function setMemberLimit($memberLimit)
+    {
+        $this->memberLimit = $memberLimit;
+    }
+}

--- a/src/Types/ChatMemberUpdated.php
+++ b/src/Types/ChatMemberUpdated.php
@@ -1,0 +1,178 @@
+<?php
+
+
+namespace TelegramBot\Api\Types;
+
+
+use TelegramBot\Api\BaseType;
+use TelegramBot\Api\TypeInterface;
+
+class ChatMemberUpdated extends BaseType implements TypeInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @var array
+     */
+    static protected $requiredParams = [
+        'chat',
+        'from',
+        'date',
+        'old_chat_member',
+        'new_chat_member'
+    ];
+
+
+    /**
+     * {@inheritdoc}
+     *
+     * @var array
+     */
+    protected static $map = [
+        'chat' => Chat::class,
+        'from' => User::class,
+        'date' => true,
+        'old_chat_member' => ChatMember::class,
+        'new_chat_member' => ChatMember::class,
+        'invite_link' => ChatInviteLink::class,
+    ];
+
+    /**
+     * Chat the user belongs to
+     *
+     * @var Chat
+     */
+    protected $chat;
+
+    /**
+     * Performer of the action, which resulted in the change
+     *
+     * @var User
+     */
+    protected $from;
+
+    /**
+     * Date the change was done in Unix time
+     *
+     * @var int
+     */
+    protected $date;
+
+    /**
+     * Previous information about the chat member
+     *
+     * @var ChatMember
+     */
+    protected $oldChatMember;
+
+    /**
+     * New information about the chat member
+     *
+     * @var ChatMember
+     */
+    protected $newChatMember;
+
+    /**
+     * Chat invite link, which was used by the user to join the chat;
+     * for joining by invite link events only.
+     *
+     * @var ChatInviteLink
+     */
+    protected $inviteLink;
+
+    /**
+     * @return Chat
+     */
+    public function getChat()
+    {
+        return $this->chat;
+    }
+
+    /**
+     * @param Chat $chat
+     */
+    public function setChat($chat)
+    {
+        $this->chat = $chat;
+    }
+
+    /**
+     * @return User
+     */
+    public function getFrom()
+    {
+        return $this->from;
+    }
+
+    /**
+     * @param User $from
+     */
+    public function setFrom($from)
+    {
+        $this->from = $from;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDate()
+    {
+        return $this->date;
+    }
+
+    /**
+     * @param int $date
+     */
+    public function setDate($date)
+    {
+        $this->date = $date;
+    }
+
+    /**
+     * @return ChatMember
+     */
+    public function getOldChatMember()
+    {
+        return $this->oldChatMember;
+    }
+
+    /**
+     * @param ChatMember $oldChatMember
+     */
+    public function setOldChatMember($oldChatMember)
+    {
+        $this->oldChatMember = $oldChatMember;
+    }
+
+    /**
+     * @return ChatMember
+     */
+    public function getNewChatMember()
+    {
+        return $this->newChatMember;
+    }
+
+    /**
+     * @param ChatMember $newChatMember
+     */
+    public function setNewChatMember($newChatMember)
+    {
+        $this->newChatMember = $newChatMember;
+    }
+
+    /**
+     * @return ChatInviteLink
+     */
+    public function getInviteLink()
+    {
+        return $this->inviteLink;
+    }
+
+    /**
+     * @param ChatInviteLink $inviteLink
+     */
+    public function setInviteLink($inviteLink)
+    {
+        $this->inviteLink = $inviteLink;
+    }
+}

--- a/src/Types/Update.php
+++ b/src/Types/Update.php
@@ -43,6 +43,8 @@ class Update extends BaseType implements TypeInterface
         'pre_checkout_query' => PreCheckoutQuery::class,
         'poll_answer' => PollAnswer::class,
         'poll' => Poll::class,
+        'my_chat_member' => ChatMemberUpdated::class,
+        'chat_member' => ChatMemberUpdated::class
     ];
 
     /**
@@ -72,6 +74,22 @@ class Update extends BaseType implements TypeInterface
      */
     protected $poll;
 
+    /**
+     * The bot's chat member status was updated in a chat.
+     * For private chats, this update is received only when the bot is blocked or unblocked by the user.
+     *
+     * @var ChatMemberUpdated
+     */
+    protected $myChatMember;
+
+    /**
+     * A chat member's status was updated in a chat.
+     * The bot must be an administrator in the chat and must explicitly specify “chat_member”
+     * in the list of allowed_updates to receive these updates.
+     *
+     * @var ChatMemberUpdated
+     */
+    protected $chatMember;
 
     /**
      * Optional. New version of a message that is known to the bot and was edited
@@ -324,4 +342,37 @@ class Update extends BaseType implements TypeInterface
     {
         $this->preCheckoutQuery = $preCheckoutQuery;
     }
+
+    /**
+     * @return ChatMemberUpdated
+     */
+    public function getMyChatMember()
+    {
+        return $this->myChatMember;
+    }
+
+    /**
+     * @param ChatMemberUpdated $myChatMember
+     */
+    public function setMyChatMember($myChatMember)
+    {
+        $this->myChatMember = $myChatMember;
+    }
+
+    /**
+     * @return ChatMemberUpdated
+     */
+    public function getChatMember()
+    {
+        return $this->chatMember;
+    }
+
+    /**
+     * @param ChatMemberUpdated $chatMember
+     */
+    public function setChatMember($chatMember)
+    {
+        $this->chatMember = $chatMember;
+    }
+
 }


### PR DESCRIPTION
Added updates about member status changes in chats, represented by the class ChatMemberUpdated and the fields my_chat_member and chat_member in the Update class. The bot must be an administrator in the chat to receive chat_member updates about other chat members. By default, only my_chat_member updates about the bot itself are received.