### PR TITLE
Fix vcard field in Contact (lowercase is correct)

### DIFF
--- a/src/BotApi.php
+++ b/src/BotApi.php
@@ -210,14 +210,14 @@ class BotApi
      * @throws \TelegramBot\Api\HttpException
      * @throws \TelegramBot\Api\InvalidJsonException
      */
-    public function call($method, array $data = null)
+    public function call($method, array $data = null, $timeout = 10)
     {
         $options = $this->proxySettings + [
             CURLOPT_URL => $this->getUrl().'/'.$method,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_POST => null,
             CURLOPT_POSTFIELDS => null,
-            CURLOPT_TIMEOUT => isset($data['timeout']) ? (int)$data['timeout'] : 10,
+            CURLOPT_TIMEOUT => $timeout,
         ];
 
         if ($data) {

--- a/src/BotApi.php
+++ b/src/BotApi.php
@@ -217,7 +217,7 @@ class BotApi
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_POST => null,
             CURLOPT_POSTFIELDS => null,
-            CURLOPT_TIMEOUT => 5,
+            CURLOPT_TIMEOUT => $data['timeout'] ? (int)$data['timeout'] : 10,
         ];
 
         if ($data) {

--- a/src/BotApi.php
+++ b/src/BotApi.php
@@ -217,7 +217,7 @@ class BotApi
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_POST => null,
             CURLOPT_POSTFIELDS => null,
-            CURLOPT_TIMEOUT => $data['timeout'] ? (int)$data['timeout'] : 10,
+            CURLOPT_TIMEOUT => isset($data['timeout']) ? (int)$data['timeout'] : 10,
         ];
 
         if ($data) {

--- a/src/Types/Contact.php
+++ b/src/Types/Contact.php
@@ -66,7 +66,7 @@ class Contact extends BaseType implements TypeInterface
      *
      * @var string
      */
-    protected $vCard;
+    protected $vcard;
 
     /**
      * @return string
@@ -137,14 +137,14 @@ class Contact extends BaseType implements TypeInterface
      */
     public function getVCard()
     {
-        return $this->vCard;
+        return $this->vcard;
     }
 
     /**
-     * @param string $vCard
+     * @param string $vcard
      */
-    public function setVCard($vCard)
+    public function setVCard($vcard)
     {
-        $this->vCard = $vCard;
+        $this->vcard = $vcard;
     }
 }


### PR DESCRIPTION
Hello, according to https://core.telegram.org/bots/api#contact, vcard property must be lowercase. TelegramBot fails after receiving message with Contact data 