### PR TITLE
PHP8.1: Add CURLStringFile in PhpDoc BotApi->sendDocument()

### DIFF
--- a/src/BotApi.php
+++ b/src/BotApi.php
@@ -970,7 +970,7 @@ class BotApi
      * Bots can currently send files of any type of up to 50 MB in size, this limit may be changed in the future.
      *
      * @param int|string $chatId chat_id or @channel_name
-     * @param \CURLFile|string $document
+     * @param \CURLFile|\CURLStringFile|string $document
      * @param string|null $caption
      * @param int|null $replyToMessageId
      * @param Types\ReplyKeyboardMarkup|Types\ReplyKeyboardHide|Types\ForceReply|


### PR DESCRIPTION
В PHP 8.1. кроме CurlFile можно передавать CURLStringFile, созданный из переменной.  Уже сейчас в PHP8.1 можно использовать этот класс, но подсветка "ругается" на не соответствие типов. 

Предлагаю в PhpDoc метода BotApi->sendDocument() добавить альтернативный класс CURLStringFile