### PR TITLE
add support for forum topic (Bot API 6.3)

### DIFF
--- a/src/BotApi.php
+++ b/src/BotApi.php
@@ -7,14 +7,20 @@ use TelegramBot\Api\Types\ArrayOfChatMemberEntity;
 use TelegramBot\Api\Types\ArrayOfMessageEntity;
 use TelegramBot\Api\Types\ArrayOfMessages;
 use TelegramBot\Api\Types\ArrayOfUpdates;
+use TelegramBot\Api\Types\BotCommand;
 use TelegramBot\Api\Types\Chat;
 use TelegramBot\Api\Types\ChatMember;
 use TelegramBot\Api\Types\File;
+use TelegramBot\Api\Types\ForceReply;
 use TelegramBot\Api\Types\Inline\QueryResult\AbstractInlineQueryResult;
 use TelegramBot\Api\Types\InputMedia\ArrayOfInputMedia;
 use TelegramBot\Api\Types\InputMedia\InputMedia;
+use TelegramBot\Api\Types\MaskPosition;
 use TelegramBot\Api\Types\Message;
 use TelegramBot\Api\Types\Poll;
+use TelegramBot\Api\Types\ReplyKeyboardHide;
+use TelegramBot\Api\Types\ReplyKeyboardMarkup;
+use TelegramBot\Api\Types\ReplyKeyboardRemove;
 use TelegramBot\Api\Types\StickerSet;
 use TelegramBot\Api\Types\Update;
 use TelegramBot\Api\Types\User;
@@ -151,7 +157,7 @@ class BotApi
     /**
      * Botan tracker
      *
-     * @var \TelegramBot\Api\Botan
+     * @var Botan
      */
     protected $tracker;
 
@@ -174,6 +180,7 @@ class BotApi
      *
      * @param string $token Telegram Bot API token
      * @param string|null $trackerToken Yandex AppMetrica application api_key
+     * @throws \Exception
      */
     public function __construct($token, $trackerToken = null)
     {
@@ -207,9 +214,9 @@ class BotApi
      * @param array|null $data
      *
      * @return mixed
-     * @throws \TelegramBot\Api\Exception
-     * @throws \TelegramBot\Api\HttpException
-     * @throws \TelegramBot\Api\InvalidJsonException
+     * @throws Exception
+     * @throws HttpException
+     * @throws InvalidJsonException
      */
     public function call($method, array $data = null, $timeout = 10)
     {
@@ -254,7 +261,7 @@ class BotApi
      *
      * @return string
      *
-     * @throws \TelegramBot\Api\HttpException
+     * @throws HttpException
      */
     protected function executeCurl(array $options)
     {
@@ -295,7 +302,7 @@ class BotApi
      * @param boolean $asArray
      *
      * @return object|array
-     * @throws \TelegramBot\Api\InvalidJsonException
+     * @throws InvalidJsonException
      */
     public static function jsonValidate($jsonString, $asArray)
     {
@@ -315,20 +322,21 @@ class BotApi
      * @param string $text
      * @param string|null $parseMode
      * @param bool $disablePreview
+     * @param int|null $messageThreadId
      * @param int|null $replyToMessageId
-     * @param Types\ReplyKeyboardMarkup|Types\ReplyKeyboardHide|Types\ForceReply|
-     *        Types\ReplyKeyboardRemove|null $replyMarkup
+     * @param ReplyKeyboardMarkup|ReplyKeyboardHide|ForceReply|ReplyKeyboardRemove|null $replyMarkup
      * @param bool $disableNotification
      *
-     * @return \TelegramBot\Api\Types\Message
-     * @throws \TelegramBot\Api\InvalidArgumentException
-     * @throws \TelegramBot\Api\Exception
+     * @return Message
+     * @throws InvalidArgumentException
+     * @throws Exception
      */
     public function sendMessage(
         $chatId,
         $text,
         $parseMode = null,
         $disablePreview = false,
+        $messageThreadId = null,
         $replyToMessageId = null,
         $replyMarkup = null,
         $disableNotification = false
@@ -336,6 +344,7 @@ class BotApi
         return Message::fromResponse($this->call('sendMessage', [
             'chat_id' => $chatId,
             'text' => $text,
+            'message_thread_id' => $messageThreadId,
             'parse_mode' => $parseMode,
             'disable_web_page_preview' => $disablePreview,
             'reply_to_message_id' => (int)$replyToMessageId,
@@ -352,10 +361,10 @@ class BotApi
      * @param string|null $parseMode
      * @param ArrayOfMessageEntity|null $captionEntities
      * @param bool $disableNotification
+     * @param int|null $messageThreadId
      * @param int|null $replyToMessageId
      * @param bool $allowSendingWithoutReply
-     * @param Types\ReplyKeyboardMarkup|Types\ReplyKeyboardHide|Types\ForceReply|
-     *        Types\ReplyKeyboardRemove|null $replyMarkup
+     * @param ReplyKeyboardMarkup|ReplyKeyboardHide|ForceReply|ReplyKeyboardRemove|null $replyMarkup
      *
      * @return Message
      * @throws Exception
@@ -370,6 +379,7 @@ class BotApi
         $parseMode = null,
         $captionEntities = null,
         $disableNotification = false,
+        $messageThreadId = null,
         $replyToMessageId = null,
         $allowSendingWithoutReply = false,
         $replyMarkup = null
@@ -382,6 +392,7 @@ class BotApi
             'parse_mode' => $parseMode,
             'caption_entities' => $captionEntities,
             'disable_notification' => (bool)$disableNotification,
+            'message_thread_id' => $messageThreadId,
             'reply_to_message_id' => (int)$replyToMessageId,
             'allow_sending_without_reply' => (bool)$allowSendingWithoutReply,
             'reply_markup' => is_null($replyMarkup) ? $replyMarkup : $replyMarkup->toJson(),
@@ -395,19 +406,20 @@ class BotApi
      * @param string $phoneNumber
      * @param string $firstName
      * @param string $lastName
+     * @param int|null $messageThreadId
      * @param int|null $replyToMessageId
-     * @param Types\ReplyKeyboardMarkup|Types\ReplyKeyboardHide|Types\ForceReply|
-     *        Types\ReplyKeyboardRemove|null $replyMarkup
+     * @param ReplyKeyboardMarkup|ReplyKeyboardHide|ForceReply|ReplyKeyboardRemove|null $replyMarkup
      * @param bool $disableNotification
      *
-     * @return \TelegramBot\Api\Types\Message
-     * @throws \TelegramBot\Api\Exception
+     * @return Message
+     * @throws Exception
      */
     public function sendContact(
         $chatId,
         $phoneNumber,
         $firstName,
         $lastName = null,
+        $messageThreadId = null,
         $replyToMessageId = null,
         $replyMarkup = null,
         $disableNotification = false
@@ -417,6 +429,7 @@ class BotApi
             'phone_number' => $phoneNumber,
             'first_name' => $firstName,
             'last_name' => $lastName,
+            'message_thread_id' => $messageThreadId,
             'reply_to_message_id' => $replyToMessageId,
             'reply_markup' => is_null($replyMarkup) ? $replyMarkup : $replyMarkup->toJson(),
             'disable_notification' => (bool)$disableNotification,
@@ -439,7 +452,7 @@ class BotApi
      * @param string $action
      *
      * @return bool
-     * @throws \TelegramBot\Api\Exception
+     * @throws Exception
      */
     public function sendChatAction($chatId, $action)
     {
@@ -456,8 +469,8 @@ class BotApi
      * @param int $offset
      * @param int $limit
      *
-     * @return \TelegramBot\Api\Types\UserProfilePhotos
-     * @throws \TelegramBot\Api\Exception
+     * @return UserProfilePhotos
+     * @throws Exception
      */
     public function getUserProfilePhotos($userId, $offset = 0, $limit = 100)
     {
@@ -496,7 +509,7 @@ class BotApi
      *
      * @return string
      *
-     * @throws \TelegramBot\Api\Exception
+     * @throws Exception
      */
     public function setWebhook(
         $url = '',
@@ -526,7 +539,7 @@ class BotApi
      *
      * @return mixed
      *
-     * @throws \TelegramBot\Api\Exception
+     * @throws Exception
      */
     public function deleteWebhook($drop_pending_updates = false)
     {
@@ -538,9 +551,9 @@ class BotApi
      * On success, returns a WebhookInfo object. If the bot is using getUpdates,
      * will return an object with the url field empty.
      *
-     * @return \TelegramBot\Api\Types\WebhookInfo
-     * @throws \TelegramBot\Api\Exception
-     * @throws \TelegramBot\Api\InvalidArgumentException
+     * @return WebhookInfo
+     * @throws Exception
+     * @throws InvalidArgumentException
      */
     public function getWebhookInfo()
     {
@@ -551,9 +564,9 @@ class BotApi
      * A simple method for testing your bot's auth token.Requires no parameters.
      * Returns basic information about the bot in form of a User object.
      *
-     * @return \TelegramBot\Api\Types\User
-     * @throws \TelegramBot\Api\Exception
-     * @throws \TelegramBot\Api\InvalidArgumentException
+     * @return User
+     * @throws Exception
+     * @throws InvalidArgumentException
      */
     public function getMe()
     {
@@ -573,8 +586,8 @@ class BotApi
      * @param int $timeout
      *
      * @return Update[]
-     * @throws \TelegramBot\Api\Exception
-     * @throws \TelegramBot\Api\InvalidArgumentException
+     * @throws Exception
+     * @throws InvalidArgumentException
      */
     public function getUpdates($offset = 0, $limit = 100, $timeout = 0)
     {
@@ -596,21 +609,25 @@ class BotApi
     /**
      * Use this method to send point on the map. On success, the sent Message is returned.
      *
-     * @param int|string                                                              $chatId
-     * @param float                                                                   $latitude
-     * @param float                                                                   $longitude
-     * @param int|null                                                                $replyToMessageId
-     * @param Types\ReplyKeyboardMarkup|Types\ReplyKeyboardHide|Types\ForceReply|
-     *        Types\ReplyKeyboardRemove|null $replyMarkup
-     * @param bool                                                                    $disableNotification
+     * @param int|string $chatId
+     * @param float $latitude
+     * @param float $longitude
+     * @param int|null $messageThreadId
+     * @param int|null $replyToMessageId
+     * @param ReplyKeyboardMarkup|ReplyKeyboardHide|ForceReply|ReplyKeyboardRemove|null $replyMarkup
+     * @param bool $disableNotification
      *
-     * @param null|int                                                                $livePeriod
-     * @return \TelegramBot\Api\Types\Message
+     * @param null|int $livePeriod
+     *
+     * @return Message
+     *
+     * @throws Exception
      */
     public function sendLocation(
         $chatId,
         $latitude,
         $longitude,
+        $messageThreadId = null,
         $replyToMessageId = null,
         $replyMarkup = null,
         $disableNotification = false,
@@ -621,6 +638,7 @@ class BotApi
             'latitude'             => $latitude,
             'longitude'            => $longitude,
             'live_period'          => $livePeriod,
+            'message_thread_id'    => $messageThreadId,
             'reply_to_message_id'  => $replyToMessageId,
             'reply_markup'         => is_null($replyMarkup) ? $replyMarkup : $replyMarkup->toJson(),
             'disable_notification' => (bool)$disableNotification,
@@ -635,9 +653,11 @@ class BotApi
      * @param string                                                                  $inlineMessageId
      * @param float                                                                   $latitude
      * @param float                                                                   $longitude
-     * @param Types\ReplyKeyboardMarkup|Types\ReplyKeyboardHide|Types\ForceReply|
-     *        Types\ReplyKeyboardRemove|null $replyMarkup
-     * @return \TelegramBot\Api\Types\Message
+     * @param ReplyKeyboardMarkup|ReplyKeyboardHide|ForceReply|ReplyKeyboardRemove|null $replyMarkup
+     *
+     * @return Message
+     *
+     * @throws Exception
      */
     public function editMessageLiveLocation(
         $chatId,
@@ -664,9 +684,11 @@ class BotApi
      * @param int|string                                                              $chatId
      * @param int                                                                     $messageId
      * @param string                                                                  $inlineMessageId
-     * @param Types\ReplyKeyboardMarkup|Types\ReplyKeyboardHide|Types\ForceReply|
-     *        Types\ReplyKeyboardRemove|null $replyMarkup
-     * @return \TelegramBot\Api\Types\Message
+     * @param ReplyKeyboardMarkup|ReplyKeyboardHide|ForceReply|ReplyKeyboardRemove|null $replyMarkup
+     *
+     * @return Message
+     *
+     * @throws Exception
      */
     public function stopMessageLiveLocation(
         $chatId,
@@ -691,13 +713,13 @@ class BotApi
      * @param string $title
      * @param string $address
      * @param string|null $foursquareId
+     * @param int|null $messageThreadId
      * @param int|null $replyToMessageId
-     * @param Types\ReplyKeyboardMarkup|Types\ReplyKeyboardHide|Types\ForceReply|
-     *        Types\ReplyKeyboardRemove|null $replyMarkup
+     * @param ReplyKeyboardMarkup|ReplyKeyboardHide|ForceReply|ReplyKeyboardRemove|null $replyMarkup
      * @param bool $disableNotification
      *
-     * @return \TelegramBot\Api\Types\Message
-     * @throws \TelegramBot\Api\Exception
+     * @return Message
+     * @throws Exception
      */
     public function sendVenue(
         $chatId,
@@ -706,6 +728,7 @@ class BotApi
         $title,
         $address,
         $foursquareId = null,
+        $messageThreadId = null,
         $replyToMessageId = null,
         $replyMarkup = null,
         $disableNotification = false
@@ -717,6 +740,7 @@ class BotApi
             'title' => $title,
             'address' => $address,
             'foursquare_id' => $foursquareId,
+            'message_thread_id' => $messageThreadId,
             'reply_to_message_id' => $replyToMessageId,
             'reply_markup' => is_null($replyMarkup) ? $replyMarkup : $replyMarkup->toJson(),
             'disable_notification' => (bool)$disableNotification,
@@ -729,19 +753,19 @@ class BotApi
      * @param int|string $chatId chat_id or @channel_name
      * @param \CURLFile|string $sticker
      * @param int|null $replyToMessageId
-     * @param Types\ReplyKeyboardMarkup|Types\ReplyKeyboardHide|Types\ForceReply|
-     *        Types\ReplyKeyboardRemove|null $replyMarkup
+     * @param null $replyMarkup
      * @param bool $disableNotification Sends the message silently. Users will receive a notification with no sound.
      * @param bool $protectContent Protects the contents of the sent message from forwarding and saving
      * @param bool $allowSendingWithoutReply Pass True if the message should be sent even if the specified replied-to message is not found
      *
-     * @return \TelegramBot\Api\Types\Message
-     * @throws \TelegramBot\Api\InvalidArgumentException
-     * @throws \TelegramBot\Api\Exception
+     * @return Message
+     * @throws InvalidArgumentException
+     * @throws Exception
      */
     public function sendSticker(
         $chatId,
         $sticker,
+        $messageThreadId = null,
         $replyToMessageId = null,
         $replyMarkup = null,
         $disableNotification = false,
@@ -751,6 +775,7 @@ class BotApi
         return Message::fromResponse($this->call('sendSticker', [
             'chat_id' => $chatId,
             'sticker' => $sticker,
+            'message_thread_id' => $messageThreadId,
             'reply_to_message_id' => $replyToMessageId,
             'reply_markup' => is_null($replyMarkup) ? $replyMarkup : $replyMarkup->toJson(),
             'disable_notification' => (bool)$disableNotification,
@@ -762,8 +787,8 @@ class BotApi
     /**
      * @param string $name Name of the sticker set
      *
-     * @throws \TelegramBot\Api\InvalidArgumentException
-     * @throws \TelegramBot\Api\Exception
+     * @throws InvalidArgumentException
+     * @throws Exception
      */
     public function getStickerSet($name)
     {
@@ -776,8 +801,8 @@ class BotApi
      * @param array[] $customEmojiIds List of custom emoji identifiers.
      *                                  At most 200 custom emoji identifiers can be specified.
      *
-     * @throws \TelegramBot\Api\InvalidArgumentException
-     * @throws \TelegramBot\Api\Exception
+     * @throws InvalidArgumentException
+     * @throws Exception
      */
     public function getCustomEmojiStickers($customEmojiIds = [])
     {
@@ -798,8 +823,8 @@ class BotApi
      *
      * @return File
      *
-     * @throws \TelegramBot\Api\InvalidArgumentException
-     * @throws \TelegramBot\Api\Exception
+     * @throws InvalidArgumentException
+     * @throws Exception
      */
     public function uploadStickerFile($userId, $pngSticker)
     {
@@ -831,10 +856,10 @@ class BotApi
      *                            See https://core.telegram.org/animated_stickers#technical-requirements for technical requirements
      * @param string $stickerType Sticker type, one of “png”, “tgs”, or “webp”
      * @param string $emojis One or more emoji corresponding to the sticker
-     * @param \TelegramBot\Api\Types\MaskPosition|null $maskPosition A JSON-serialized object for position where the mask should be placed on faces
+     * @param MaskPosition|null $maskPosition A JSON-serialized object for position where the mask should be placed on faces
      *
-     * @throws \TelegramBot\Api\InvalidArgumentException
-     * @throws \TelegramBot\Api\Exception
+     * @throws InvalidArgumentException
+     * @throws Exception
      */
     public function createNewStickerSet(
         $userId,
@@ -867,8 +892,8 @@ class BotApi
      * Animated sticker sets can have up to 50 stickers.
      * Static sticker sets can have up to 120 stickers. Returns True on success.
      *
-     * @throws \TelegramBot\Api\InvalidArgumentException
-     * @throws \TelegramBot\Api\Exception
+     * @throws InvalidArgumentException
+     * @throws Exception
      */
     public function addStickerToSet(
         $userId,
@@ -899,8 +924,8 @@ class BotApi
      *
      * @return bool
      *
-     * @throws \TelegramBot\Api\InvalidArgumentException
-     * @throws \TelegramBot\Api\Exception
+     * @throws InvalidArgumentException
+     * @throws Exception
      */
     public function setStickerPositionInSet($sticker, $position)
     {
@@ -922,8 +947,8 @@ class BotApi
      *
      * @return bool
      *
-     * @throws \TelegramBot\Api\InvalidArgumentException
-     * @throws \TelegramBot\Api\Exception
+     * @throws InvalidArgumentException
+     * @throws Exception
      */
     public function setStickerSetThumb($name, $userId, $thumb = null)
     {
@@ -943,22 +968,23 @@ class BotApi
      * @param \CURLFile|string $video
      * @param int|null $duration
      * @param string|null $caption
+     * @param int|null $messageThreadId
      * @param int|null $replyToMessageId
-     * @param Types\ReplyKeyboardMarkup|Types\ReplyKeyboardHide|Types\ForceReply|
-     *        Types\ReplyKeyboardRemove|null $replyMarkup
+     * @param ReplyKeyboardMarkup|ReplyKeyboardHide|ForceReply|ReplyKeyboardRemove|null $replyMarkup
      * @param bool $disableNotification
      * @param bool $supportsStreaming Pass True, if the uploaded video is suitable for streaming
      * @param string|null $parseMode
      *
-     * @return \TelegramBot\Api\Types\Message
-     * @throws \TelegramBot\Api\InvalidArgumentException
-     * @throws \TelegramBot\Api\Exception
+     * @return Message
+     * @throws InvalidArgumentException
+     * @throws Exception
      */
     public function sendVideo(
         $chatId,
         $video,
         $duration = null,
         $caption = null,
+        $messageThreadId = null,
         $replyToMessageId = null,
         $replyMarkup = null,
         $disableNotification = false,
@@ -970,6 +996,7 @@ class BotApi
             'video' => $video,
             'duration' => $duration,
             'caption' => $caption,
+            'message_thread_id' => $messageThreadId,
             'reply_to_message_id' => $replyToMessageId,
             'reply_markup' => is_null($replyMarkup) ? $replyMarkup : $replyMarkup->toJson(),
             'disable_notification' => (bool)$disableNotification,
@@ -987,21 +1014,22 @@ class BotApi
      * @param \CURLFile|string $animation
      * @param int|null $duration
      * @param string|null $caption
+     * @param int|null $messageThreadId
      * @param int|null $replyToMessageId
-     * @param Types\ReplyKeyboardMarkup|Types\ReplyKeyboardHide|Types\ForceReply|
-     *        Types\ReplyKeyboardRemove|null $replyMarkup
+     * @param ReplyKeyboardMarkup|ReplyKeyboardHide|ForceReply|ReplyKeyboardRemove|null $replyMarkup
      * @param bool $disableNotification
      * @param string|null $parseMode
      *
-     * @return \TelegramBot\Api\Types\Message
-     * @throws \TelegramBot\Api\InvalidArgumentException
-     * @throws \TelegramBot\Api\Exception
+     * @return Message
+     * @throws InvalidArgumentException
+     * @throws Exception
      */
     public function sendAnimation(
         $chatId,
         $animation,
         $duration = null,
         $caption = null,
+        $messageThreadId = null,
         $replyToMessageId = null,
         $replyMarkup = null,
         $disableNotification = false,
@@ -1012,6 +1040,7 @@ class BotApi
             'animation' => $animation,
             'duration' => $duration,
             'caption' => $caption,
+            'message_thread_id' => $messageThreadId,
             'reply_to_message_id' => $replyToMessageId,
             'reply_markup' => is_null($replyMarkup) ? $replyMarkup : $replyMarkup->toJson(),
             'disable_notification' => (bool)$disableNotification,
@@ -1027,27 +1056,28 @@ class BotApi
      * On success, the sent Message is returned.
      * Bots can currently send voice messages of up to 50 MB in size, this limit may be changed in the future.
      *
-     * @param int|string       $chatId chat_id or @channel_name
+     * @param int|string $chatId chat_id or @channel_name
      * @param \CURLFile|string $voice
-     * @param string           $caption Voice message caption, 0-1024 characters after entities parsing
-     * @param int|null         $duration
-     * @param int|null         $replyToMessageId
-     * @param Types\ReplyKeyboardMarkup|Types\ReplyKeyboardHide|Types\ForceReply|
-     *        Types\ReplyKeyboardRemove|null $replyMarkup
-     * @param bool             $disableNotification
-     * @param bool             $allowSendingWithoutReply Pass True, if the message should be sent even if the specified
+     * @param string $caption Voice message caption, 0-1024 characters after entities parsing
+     * @param int|null $duration
+     * @param int|null $messageThreadId
+     * @param int|null $replyToMessageId
+     * @param ReplyKeyboardMarkup|ReplyKeyboardHide|ForceReply|ReplyKeyboardRemove|null $replyMarkup
+     * @param bool $disableNotification
+     * @param bool $allowSendingWithoutReply Pass True, if the message should be sent even if the specified
      *     replied-to message is not found
-     * @param string|null      $parseMode
+     * @param string|null $parseMode
      *
-     * @return \TelegramBot\Api\Types\Message
-     * @throws \TelegramBot\Api\InvalidArgumentException
-     * @throws \TelegramBot\Api\Exception
+     * @return Message
+     * @throws InvalidArgumentException
+     * @throws Exception
      */
     public function sendVoice(
         $chatId,
         $voice,
         $caption = null,
         $duration = null,
+        $messageThreadId = null,
         $replyToMessageId = null,
         $replyMarkup = null,
         $disableNotification = false,
@@ -1059,6 +1089,7 @@ class BotApi
             'voice' => $voice,
             'caption' => $caption,
             'duration' => $duration,
+            'message_thread_id' => $messageThreadId,
             'reply_to_message_id' => $replyToMessageId,
             'reply_markup' => is_null($replyMarkup) ? $replyMarkup : $replyMarkup->toJson(),
             'disable_notification' => (bool)$disableNotification,
@@ -1068,23 +1099,35 @@ class BotApi
     }
 
     /**
-     * Use this method to forward messages of any kind. On success, the sent Message is returned.
+     * Use this method to forward messages of any kind. Service messages can't be forwarded.
+     * On success, the sent Message is returned.
      *
-     * @param int|string $chatId chat_id or @channel_name
-     * @param int $fromChatId
-     * @param int $messageId
-     * @param bool $disableNotification
+     * @param int|string $chatId Unique identifier for the target chat or username of the target channel (in the format @channelusername)
+     * @param int $fromChatId Unique identifier for the chat where the original message was sent (or channel username in the format @channelusername)
+     * @param $messageId Message identifier in the chat specified in from_chat_id
+     * @param int|null $messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
+     * @param bool $protectContent Protects the contents of the forwarded message from forwarding and saving
+     * @param bool $disableNotification Sends the message silently. Users will receive a notification with no sound.
      *
-     * @return \TelegramBot\Api\Types\Message
-     * @throws \TelegramBot\Api\InvalidArgumentException
-     * @throws \TelegramBot\Api\Exception
+     * @return Message
+     * @throws Exception
+     * @throws HttpException
+     * @throws InvalidJsonException
      */
-    public function forwardMessage($chatId, $fromChatId, $messageId, $disableNotification = false)
-    {
+    public function forwardMessage(
+        $chatId,
+        $fromChatId,
+        $messageId,
+        $messageThreadId = null,
+        $protectContent = false,
+        $disableNotification = false
+    ) {
         return Message::fromResponse($this->call('forwardMessage', [
             'chat_id' => $chatId,
             'from_chat_id' => $fromChatId,
-            'message_id' => (int)$messageId,
+            'message_id' => $messageId,
+            'message_thread_id' => $messageThreadId,
+            'protect_content' => $protectContent,
             'disable_notification' => (bool)$disableNotification,
         ]));
     }
@@ -1101,24 +1144,23 @@ class BotApi
      * For this to work, the audio must be in an .ogg file encoded with OPUS.
      * This behavior will be phased out in the future. For sending voice messages, use the sendVoice method instead.
      *
-     * @deprecated since 20th February. Removed backward compatibility from the method sendAudio.
-     * Voice messages now must be sent using the method sendVoice.
-     * There is no more need to specify a non-empty title or performer while sending the audio by file_id.
-     *
      * @param int|string $chatId chat_id or @channel_name
      * @param \CURLFile|string $audio
      * @param int|null $duration
      * @param string|null $performer
      * @param string|null $title
      * @param int|null $replyToMessageId
-     * @param Types\ReplyKeyboardMarkup|Types\ReplyKeyboardHide|Types\ForceReply|
-     *        Types\ReplyKeyboardRemove|null $replyMarkup
+     * @param ReplyKeyboardMarkup|ReplyKeyboardHide|ForceReply|ReplyKeyboardRemove|null $replyMarkup
      * @param bool $disableNotification
      * @param string|null $parseMode
      *
-     * @return \TelegramBot\Api\Types\Message
-     * @throws \TelegramBot\Api\InvalidArgumentException
-     * @throws \TelegramBot\Api\Exception
+     * @return Message
+     * @throws InvalidArgumentException
+     * @throws Exception
+     * @deprecated since 20th February. Removed backward compatibility from the method sendAudio.
+     * Voice messages now must be sent using the method sendVoice.
+     * There is no more need to specify a non-empty title or performer while sending the audio by file_id.
+     *
      */
     public function sendAudio(
         $chatId,
@@ -1150,20 +1192,21 @@ class BotApi
      * @param int|string $chatId chat_id or @channel_name
      * @param \CURLFile|string $photo
      * @param string|null $caption
+     * @param int|null $messageThreadId
      * @param int|null $replyToMessageId
-     * @param Types\ReplyKeyboardMarkup|Types\ReplyKeyboardHide|Types\ForceReply|
-     *        Types\ReplyKeyboardRemove|null $replyMarkup
+     * @param ReplyKeyboardMarkup|ReplyKeyboardHide|ForceReply|ReplyKeyboardRemove|null $replyMarkup
      * @param bool $disableNotification
      * @param string|null $parseMode
      *
-     * @return \TelegramBot\Api\Types\Message
-     * @throws \TelegramBot\Api\InvalidArgumentException
-     * @throws \TelegramBot\Api\Exception
+     * @return Message
+     * @throws InvalidArgumentException
+     * @throws Exception
      */
     public function sendPhoto(
         $chatId,
         $photo,
         $caption = null,
+        $messageThreadId = null,
         $replyToMessageId = null,
         $replyMarkup = null,
         $disableNotification = false,
@@ -1173,6 +1216,7 @@ class BotApi
             'chat_id' => $chatId,
             'photo' => $photo,
             'caption' => $caption,
+            'message_thread_id' => $messageThreadId,
             'reply_to_message_id' => $replyToMessageId,
             'reply_markup' => is_null($replyMarkup) ? $replyMarkup : $replyMarkup->toJson(),
             'disable_notification' => (bool)$disableNotification,
@@ -1187,20 +1231,21 @@ class BotApi
      * @param int|string $chatId chat_id or @channel_name
      * @param \CURLFile|string $document
      * @param string|null $caption
+     * @param int|null $messageThreadId
      * @param int|null $replyToMessageId
-     * @param Types\ReplyKeyboardMarkup|Types\ReplyKeyboardHide|Types\ForceReply|
-     *        Types\ReplyKeyboardRemove|null $replyMarkup
+     * @param ReplyKeyboardMarkup|ReplyKeyboardHide|ForceReply|ReplyKeyboardRemove|null $replyMarkup
      * @param bool $disableNotification
      * @param string|null $parseMode
      *
-     * @return \TelegramBot\Api\Types\Message
-     * @throws \TelegramBot\Api\InvalidArgumentException
-     * @throws \TelegramBot\Api\Exception
+     * @return Message
+     * @throws InvalidArgumentException
+     * @throws Exception
      */
     public function sendDocument(
         $chatId,
         $document,
         $caption = null,
+        $messageThreadId = null,
         $replyToMessageId = null,
         $replyMarkup = null,
         $disableNotification = false,
@@ -1210,6 +1255,7 @@ class BotApi
             'chat_id' => $chatId,
             'document' => $document,
             'caption' => $caption,
+            'message_thread_id' => $messageThreadId,
             'reply_to_message_id' => $replyToMessageId,
             'reply_markup' => is_null($replyMarkup) ? $replyMarkup : $replyMarkup->toJson(),
             'disable_notification' => (bool)$disableNotification,
@@ -1228,9 +1274,9 @@ class BotApi
      *
      * @param $fileId
      *
-     * @return \TelegramBot\Api\Types\File
-     * @throws \TelegramBot\Api\InvalidArgumentException
-     * @throws \TelegramBot\Api\Exception
+     * @return File
+     * @throws InvalidArgumentException
+     * @throws Exception
      */
     public function getFile($fileId)
     {
@@ -1244,7 +1290,8 @@ class BotApi
      *
      * @return string
      *
-     * @throws \TelegramBot\Api\HttpException
+     * @throws HttpException
+     * @throws Exception
      */
     public function downloadFile($fileId)
     {
@@ -1313,6 +1360,7 @@ class BotApi
      *                            they are considered to be banned forever
      *
      * @return bool
+     * @throws Exception
      */
     public function kickChatMember($chatId, $userId, $untilDate = null)
     {
@@ -1333,6 +1381,7 @@ class BotApi
      * @param int $userId Unique identifier of the target user
      *
      * @return bool
+     * @throws Exception
      */
     public function unbanChatMember($chatId, $userId)
     {
@@ -1353,6 +1402,7 @@ class BotApi
      * @param int $cacheTime
      *
      * @return bool
+     * @throws Exception
      */
     public function answerCallbackQuery($callbackQueryId, $text = null, $showAlert = false, $url = null, $cacheTime = 0)
     {
@@ -1389,7 +1439,8 @@ class BotApi
      * Use this method to get the current list of the bot's commands. Requires no parameters.
      * Returns Array of BotCommand on success.
      *
-     * @return mixed
+     * @return BotCommand[]
+     *
      * @throws Exception
      * @throws HttpException
      * @throws InvalidJsonException
@@ -1408,9 +1459,10 @@ class BotApi
      * @param string $inlineMessageId
      * @param string|null $parseMode
      * @param bool $disablePreview
-     * @param Types\ReplyKeyboardMarkup|Types\ReplyKeyboardHide|Types\ForceReply|
-     *        Types\ReplyKeyboardRemove|null $replyMarkup
+     * @param ReplyKeyboardMarkup|ReplyKeyboardHide|ForceReply|ReplyKeyboardRemove|null $replyMarkup
+     *
      * @return Message
+     * @throws Exception
      */
     public function editMessageText(
         $chatId,
@@ -1438,14 +1490,13 @@ class BotApi
      * @param int|string $chatId
      * @param int $messageId
      * @param string|null $caption
-     * @param Types\ReplyKeyboardMarkup|Types\ReplyKeyboardHide|Types\ForceReply|
-     *        Types\ReplyKeyboardRemove|null $replyMarkup
+     * @param ReplyKeyboardMarkup|ReplyKeyboardHide|ForceReply|ReplyKeyboardRemove|null $replyMarkup
      * @param string $inlineMessageId
      * @param string|null $parseMode
      *
-     * @return \TelegramBot\Api\Types\Message
-     * @throws \TelegramBot\Api\InvalidArgumentException
-     * @throws \TelegramBot\Api\Exception
+     * @return Message
+     * @throws InvalidArgumentException
+     * @throws Exception
      */
     public function editMessageCaption(
         $chatId,
@@ -1479,6 +1530,7 @@ class BotApi
      * @param string|null $inlineMessageId
      * @param string|null $replyMarkup
      * @return bool|Message
+     *
      * @throws Exception
      * @throws HttpException
      * @throws InvalidJsonException
@@ -1504,11 +1556,11 @@ class BotApi
      *
      * @param int|string $chatId
      * @param int $messageId
-     * @param Types\ReplyKeyboardMarkup|Types\ReplyKeyboardHide|Types\ForceReply|
-     *        Types\ReplyKeyboardRemove|null $replyMarkup
+     * @param ReplyKeyboardMarkup|ReplyKeyboardHide|ForceReply|ReplyKeyboardRemove|null $replyMarkup
      * @param string $inlineMessageId
      *
      * @return Message
+     * @throws Exception
      */
     public function editMessageReplyMarkup(
         $chatId,
@@ -1536,6 +1588,7 @@ class BotApi
      * @param int $messageId
      *
      * @return bool
+     * @throws Exception
      */
     public function deleteMessage($chatId, $messageId)
     {
@@ -1570,10 +1623,10 @@ class BotApi
     }
 
     /**
-     * @param \TelegramBot\Api\Types\Update $update
+     * @param Update $update
      * @param string $eventName
      *
-     * @throws \TelegramBot\Api\Exception
+     * @throws Exception
      */
     public function trackUpdate(Update $update, $eventName = 'Message')
     {
@@ -1591,10 +1644,10 @@ class BotApi
     /**
      * Wrapper for tracker
      *
-     * @param \TelegramBot\Api\Types\Message $message
+     * @param Message $message
      * @param string $eventName
      *
-     * @throws \TelegramBot\Api\Exception
+     * @throws Exception
      */
     public function track(Message $message, $eventName = 'Message')
     {
@@ -1614,6 +1667,7 @@ class BotApi
      * @param string $startParameter
      * @param string $currency
      * @param array $prices
+     * @param bool $isFlexible
      * @param string|null $photoUrl
      * @param int|null $photoSize
      * @param int|null $photoWidth
@@ -1622,16 +1676,16 @@ class BotApi
      * @param bool $needPhoneNumber
      * @param bool $needEmail
      * @param bool $needShippingAddress
-     * @param bool $isFlexible
+     * @param int|null $messageThreadId
      * @param int|null $replyToMessageId
-     * @param Types\ReplyKeyboardMarkup|Types\ReplyKeyboardHide|Types\ForceReply|
-     *        Types\ReplyKeyboardRemove|null $replyMarkup
+     * @param ReplyKeyboardMarkup|ReplyKeyboardHide|ForceReply|ReplyKeyboardRemove|null $replyMarkup
      * @param bool $disableNotification
      * @param string|null $providerData
      * @param bool $sendPhoneNumberToProvider
      * @param bool $sendEmailToProvider
      *
      * @return Message
+     * @throws Exception
      */
     public function sendInvoice(
         $chatId,
@@ -1651,6 +1705,7 @@ class BotApi
         $needPhoneNumber = false,
         $needEmail = false,
         $needShippingAddress = false,
+        $messageThreadId = null,
         $replyToMessageId = null,
         $replyMarkup = null,
         $disableNotification = false,
@@ -1696,7 +1751,7 @@ class BotApi
      * @param null|string $errorMessage
      *
      * @return bool
-     *
+     * @throws Exception
      */
     public function answerShippingQuery($shippingQueryId, $ok = true, $shipping_options = [], $errorMessage = null)
     {
@@ -1717,6 +1772,7 @@ class BotApi
      * @param null|string $errorMessage
      *
      * @return mixed
+     * @throws Exception
      */
     public function answerPreCheckoutQuery($preCheckoutQueryId, $ok = true, $errorMessage = null)
     {
@@ -1747,6 +1803,7 @@ class BotApi
      *                                    implies can_send_media_messages
      *
      * @return bool
+     * @throws Exception
      */
     public function restrictChatMember(
         $chatId,
@@ -1788,6 +1845,7 @@ class BotApi
      *                                indirectly (promoted by administrators that were appointed by him)
      *
      * @return bool
+     * @throws Exception
      */
     public function promoteChatMember(
         $chatId,
@@ -1822,6 +1880,7 @@ class BotApi
      * @param string|int $chatId Unique identifier for the target chat or username of the target channel
      *                           (in the format @channelusername)
      * @return string
+     * @throws Exception
      */
     public function exportChatInviteLink($chatId)
     {
@@ -1839,6 +1898,7 @@ class BotApi
      * @param \CURLFile|string $photo New chat photo, uploaded using multipart/form-data
      *
      * @return bool
+     * @throws Exception
      */
     public function setChatPhoto($chatId, $photo)
     {
@@ -1856,6 +1916,7 @@ class BotApi
      *                           (in the format @channelusername)
      *
      * @return bool
+     * @throws Exception
      */
     public function deleteChatPhoto($chatId)
     {
@@ -1873,6 +1934,7 @@ class BotApi
      * @param string $title New chat title, 1-255 characters
      *
      * @return bool
+     * @throws Exception
      */
     public function setChatTitle($chatId, $title)
     {
@@ -1891,6 +1953,7 @@ class BotApi
      * @param string|null $description New chat description, 0-255 characters
      *
      * @return bool
+     * @throws Exception
      */
     public function setChatDescription($chatId, $description = null)
     {
@@ -1910,6 +1973,7 @@ class BotApi
      * @param bool $disableNotification
      *
      * @return bool
+     * @throws Exception
      */
     public function pinChatMessage($chatId, $messageId, $disableNotification = false)
     {
@@ -1928,6 +1992,7 @@ class BotApi
      *                   (in the format @channelusername)
      *
      * @return bool
+     * @throws Exception
      */
     public function unpinChatMessage($chatId)
     {
@@ -1944,6 +2009,7 @@ class BotApi
      *                   (in the format @channelusername)
      *
      * @return Chat
+     * @throws Exception
      */
     public function getChat($chatId)
     {
@@ -1960,6 +2026,7 @@ class BotApi
      * @param int $userId
      *
      * @return ChatMember
+     * @throws Exception
      */
     public function getChatMember($chatId, $userId)
     {
@@ -1976,6 +2043,7 @@ class BotApi
      *                   (in the format @channelusername)
      *
      * @return bool
+     * @throws Exception
      */
     public function leaveChat($chatId)
     {
@@ -1991,6 +2059,7 @@ class BotApi
      *                   (in the format @channelusername)
      *
      * @return int
+     * @throws Exception
      */
     public function getChatMembersCount($chatId)
     {
@@ -2008,7 +2077,9 @@ class BotApi
      * @param string|int $chatId Unique identifier for the target chat or username of the target channel
      *                   (in the format @channelusername)
      *
-     * @return array
+     * @return ChatMember[]
+     * @throws InvalidArgumentException
+     * @throws Exception
      */
     public function getChatAdministrators($chatId)
     {
@@ -2031,20 +2102,21 @@ class BotApi
      * @param \CURLFile|string $videoNote
      * @param int|null $duration
      * @param int|null $length
+     * @param int|null $messageThreadId
      * @param int|null $replyToMessageId
-     * @param Types\ReplyKeyboardMarkup|Types\ReplyKeyboardHide|Types\ForceReply|
-     *        Types\ReplyKeyboardRemove|null $replyMarkup
+     * @param ReplyKeyboardMarkup|ReplyKeyboardHide|ForceReply|ReplyKeyboardRemove|null $replyMarkup
      * @param bool $disableNotification
      *
-     * @return \TelegramBot\Api\Types\Message
-     * @throws \TelegramBot\Api\InvalidArgumentException
-     * @throws \TelegramBot\Api\Exception
+     * @return Message
+     * @throws InvalidArgumentException
+     * @throws Exception
      */
     public function sendVideoNote(
         $chatId,
         $videoNote,
         $duration = null,
         $length = null,
+        $messageThreadId = null,
         $replyToMessageId = null,
         $replyMarkup = null,
         $disableNotification = false
@@ -2054,6 +2126,7 @@ class BotApi
             'video_note' => $videoNote,
             'duration' => $duration,
             'length' => $length,
+            'message_thread_id' => $messageThreadId,
             'reply_to_message_id' => $replyToMessageId,
             'reply_markup' => is_null($replyMarkup) ? $replyMarkup : $replyMarkup->toJson(),
             'disable_notification' => (bool)$disableNotification
@@ -2066,21 +2139,24 @@ class BotApi
      *
      * @param int|string $chatId
      * @param ArrayOfInputMedia $media
-     * @param int|null $replyToMessageId
      * @param bool $disableNotification
+     * @param int|null $messageThreadId
+     * @param int|null $replyToMessageId
      *
-     * @return array
-     * @throws \TelegramBot\Api\Exception
+     * @return Message[]
+     * @throws Exception
      */
     public function sendMediaGroup(
         $chatId,
         $media,
         $disableNotification = false,
+        $messageThreadId = null,
         $replyToMessageId = null
     ) {
         return ArrayOfMessages::fromResponse($this->call('sendMediaGroup', [
             'chat_id' => $chatId,
             'media' => $media->toJson(),
+            'message_thread_id' => $messageThreadId,
             'reply_to_message_id' => (int)$replyToMessageId,
             'disable_notification' => (bool)$disableNotification
         ]));
@@ -2126,12 +2202,13 @@ class BotApi
      *                          ignored for polls in quiz mode, defaults to False
      * @param string|null $correctOptionId 0-based identifier of the correct answer option, required for polls in quiz mode
      * @param bool $isClosed Pass True, if the poll needs to be immediately closed. This can be useful for poll preview.
+     * @param int|null $messageThreadId Unique identifier for the target message thread (topic) of the forum; for forum supergroups only
      * @param bool $disableNotification Sends the message silently. Users will receive a notification with no sound.
      * @param int|null $replyToMessageId If the message is a reply, ID of the original message
      * @param object|null $replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard,
      *                          custom reply keyboard, instructions to remove reply
      *                          keyboard or to force a reply from the user.
-     * @return \TelegramBot\Api\Types\Message
+     * @return Message
      * @throws Exception
      * @throws HttpException
      * @throws InvalidJsonException
@@ -2145,6 +2222,7 @@ class BotApi
         $allowsMultipleAnswers = false,
         $correctOptionId = null,
         $isClosed = false,
+        $messageThreadId = null,
         $disableNotification = false,
         $replyToMessageId = null,
         $replyMarkup = null
@@ -2159,6 +2237,7 @@ class BotApi
             'correct_option_id' => (int) $correctOptionId,
             'is_closed' => (bool) $isClosed,
             'disable_notification' => (bool) $disableNotification,
+            'message_thread_id' => $messageThreadId,
             'reply_to_message_id' => (int) $replyToMessageId,
             'reply_markup' => $replyMarkup === null ? $replyMarkup : $replyMarkup->toJson(),
         ]));
@@ -2175,8 +2254,9 @@ class BotApi
      *     “🎯”, “🏀”, “⚽”, or “🎰”. Dice can have values 1-6 for “🎲” and “🎯”, values 1-5 for “🏀” and “⚽”, and
      *     values 1-64 for “🎰”. Defaults to “🎲
      * @param bool $disableNotification Sends the message silently. Users will receive a notification with no sound.
+     * @param int|null $messageThreadId
      * @param string|null $replyToMessageId If the message is a reply, ID of the original message
-     * @param bool $$allowSendingWithoutReply Pass True, if the message should be sent even if the specified replied-to
+     * @param bool $allowSendingWithoutReply Pass True, if the message should be sent even if the specified replied-to
      *     message is not found,
      * @param object|null $replyMarkup Additional interface options. A JSON-serialized object for an inline keyboard,
      *                          custom reply keyboard, instructions to remove reply
@@ -2191,6 +2271,7 @@ class BotApi
         $chatId,
         $emoji,
         $disableNotification = false,
+        $messageThreadId = null,
         $replyToMessageId = null,
         $allowSendingWithoutReply = false,
         $replyMarkup = null
@@ -2199,6 +2280,7 @@ class BotApi
             'chat_id' => $chatId,
             'emoji' => $emoji,
             'disable_notification' => (bool) $disableNotification,
+            'message_thread_id' => $messageThreadId,
             'reply_to_message_id' => (int) $replyToMessageId,
             'allow_sending_without_reply' => (bool) $allowSendingWithoutReply,
             'reply_markup' => $replyMarkup === null ? $replyMarkup : $replyMarkup->toJson(),
@@ -2211,11 +2293,10 @@ class BotApi
      *
      * @param int|string $chatId
      * @param int $messageId
-     * @param Types\ReplyKeyboardMarkup|Types\ReplyKeyboardHide|Types\ForceReply|
-     *        Types\ReplyKeyboardRemove|null $replyMarkup
+     * @param ReplyKeyboardMarkup|ReplyKeyboardHide|ForceReply|ReplyKeyboardRemove|null $replyMarkup
      * @return Poll
-     * @throws \TelegramBot\Api\InvalidArgumentException
-     * @throws \TelegramBot\Api\Exception
+     * @throws InvalidArgumentException
+     * @throws Exception
      */
     public function stopPoll(
         $chatId,

--- a/src/BotApi.php
+++ b/src/BotApi.php
@@ -476,27 +476,60 @@ class BotApi
      * @param string $url HTTPS url to send updates to. Use an empty string to remove webhook integration
      * @param \CURLFile|string $certificate Upload your public key certificate
      *                                      so that the root certificate in use can be checked
+     * @param string|null $ip_address The fixed IP address which will be used to send webhook requests
+     *                                instead of the IP address resolved through DNS
+     * @param int|null $max_connections The maximum allowed number of simultaneous HTTPS connections to the webhook
+     *                                  for update delivery, 1-100. Defaults to 40. Use lower values to limit
+     *                                  the load on your bot's server, and higher values to increase your bot's throughput.
+     * @param array|null $allowed_updates A JSON-serialized list of the update types you want your bot to receive.
+     *                                    For example, specify [“message”, “edited_channel_post”, “callback_query”]
+     *                                   to only receive updates of these types. See Update for a complete list of available update types.
+     *                                   Specify an empty list to receive all update types except chat_member (default).
+     *                                   If not specified, the previous setting will be used.
+     *                                   Please note that this parameter doesn't affect updates created before the call to the setWebhook,
+     *                                   so unwanted updates may be received for a short period of time.
+     * @param bool|null $drop_pending_updates Pass True to drop all pending updates
+     * @param string|null $secret_token A secret token to be sent in a header “X-Telegram-Bot-Api-Secret-Token” in every webhook request,
+     *                                  1-256 characters. Only characters A-Z, a-z, 0-9, _ and - are allowed.
+     *                                  The header is useful to ensure that the request comes from a webhook set by you.
      *
      * @return string
      *
      * @throws \TelegramBot\Api\Exception
      */
-    public function setWebhook($url = '', $certificate = null)
-    {
-        return $this->call('setWebhook', ['url' => $url, 'certificate' => $certificate]);
+    public function setWebhook(
+        $url = '',
+        $certificate = null,
+        $ip_address = null,
+        $max_connections = 40,
+        $allowed_updates = null,
+        $drop_pending_updates = false,
+        $secret_token = null
+    ) {
+        return $this->call('setWebhook', [
+            'url' => $url,
+            'certificate' => $certificate,
+            'ip_address' => $ip_address,
+            'max_connections' => $max_connections,
+            'allowed_updates' => $allowed_updates,
+            'drop_pending_updates' => $drop_pending_updates,
+            'secret_token' => $secret_token
+        ]);
     }
 
 
     /**
      * Use this method to clear webhook and use getUpdates again!
      *
+     * @param bool $drop_pending_updates Pass True to drop all pending updates
+     *
      * @return mixed
      *
      * @throws \TelegramBot\Api\Exception
      */
-    public function deleteWebhook()
+    public function deleteWebhook($drop_pending_updates = false)
     {
-        return $this->call('deleteWebhook');
+        return $this->call('deleteWebhook', ['drop_pending_updates' => $drop_pending_updates]);
     }
 
     /**

--- a/src/Types/Animation.php
+++ b/src/Types/Animation.php
@@ -19,7 +19,7 @@ class Animation extends BaseType implements TypeInterface
      *
      * @var array
      */
-    static protected $requiredParams = ['file_id', 'width', 'height', 'duration'];
+    static protected $requiredParams = ['file_id', 'file_unique_id', 'width', 'height', 'duration'];
 
     /**
      * {@inheritdoc}
@@ -28,6 +28,7 @@ class Animation extends BaseType implements TypeInterface
      */
     static protected $map = [
         'file_id' => true,
+        'file_unique_id' => true,
         'width' => true,
         'height' => true,
         'duration' => true,

--- a/src/Types/ArrayOfSticker.php
+++ b/src/Types/ArrayOfSticker.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TelegramBot\Api\Types;
+
+abstract class ArrayOfSticker
+{
+    public static function fromResponse($data)
+    {
+        $arrayOfStickers = [];
+        foreach ($data as $sticker) {
+            $arrayOfStickers[] = Sticker::fromResponse($sticker);
+        }
+
+        return $arrayOfStickers;
+    }
+}

--- a/src/Types/Audio.php
+++ b/src/Types/Audio.php
@@ -19,7 +19,7 @@ class Audio extends BaseType implements TypeInterface
      *
      * @var array
      */
-    static protected $requiredParams = ['file_id', 'duration'];
+    static protected $requiredParams = ['file_id', 'file_unique_id', 'duration'];
 
     /**
      * {@inheritdoc}
@@ -28,6 +28,7 @@ class Audio extends BaseType implements TypeInterface
      */
     static protected $map = [
         'file_id' => true,
+        'file_unique_id' => true,
         'duration' => true,
         'performer' => true,
         'title' => true,
@@ -76,6 +77,13 @@ class Audio extends BaseType implements TypeInterface
      * @var int
      */
     protected $fileSize;
+
+    /**
+     * Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+     *
+     * @var string
+     */
+    protected $fileUniqueId;
 
     /**
      * @return int
@@ -183,5 +191,21 @@ class Audio extends BaseType implements TypeInterface
     public function setMimeType($mimeType)
     {
         $this->mimeType = $mimeType;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFileUniqueId()
+    {
+        return $this->fileUniqueId;
+    }
+
+    /**
+     * @param string $fileUniqueId
+     */
+    public function setFileUniqueId($fileUniqueId)
+    {
+        $this->fileUniqueId = $fileUniqueId;
     }
 }

--- a/src/Types/Chat.php
+++ b/src/Types/Chat.php
@@ -195,48 +195,50 @@ class Chat extends BaseType implements TypeInterface
     protected $messageAutoDeleteTime;
 
     /**
-     * Optional. True, if the chat has a custom title. Returned only in getChat.
+     * 	Optional. True, if messages from the chat can't be forwarded to other chats. Returned only in getChat.
      *
      * @var bool
      */
     protected $hasProtectedContent;
 
     /**
-     * Optional. True, if the chat is a forum. Returned only in getChat.
+     * Optional. True, if the supergroup chat is a forum (has topics enabled)
      *
      * @var bool
      */
     protected $isForum;
 
     /**
-     * Optional. True, if the chat is a forum. Returned only in getChat.
+     * Optional. If non-empty, the list of all active chat usernames;
+     * for private chats, supergroups and channels. Returned only in getChat.
      *
      * @var array[]
      */
     protected $activeUsernames;
 
     /**
-     * Optional. True, if the chat is a forum. Returned only in getChat.
+     * Optional. Custom emoji identifier of emoji status of the other party in a private chat. Returned only in getChat.
      *
-     * @var bool
+     * @var string
      */
     protected $emojiStatusCustomEmojiId;
 
     /**
-     * Optional. True, if the chat is a forum. Returned only in getChat.
+     * Optional. True, if privacy settings of the other party in the private chat allows
+     * to use tg://user?id=<user_id> links only in chats with the user.
+     * Returned only in getChat.
      *
      * @var bool
      */
     protected $hasPrivateForwards;
 
     /**
-     * Optional. True, if the chat is a forum. Returned only in getChat.
+     * Optional. True, if the privacy settings of the other party restrict sending voice and video note messages in the private chat.
+     * Returned only in getChat.
      *
      * @var bool
      */
     protected $hasRestrictedVoiceAndVideoMessages;
-
-
 
     /**
      * @return int|string
@@ -471,7 +473,7 @@ class Chat extends BaseType implements TypeInterface
     /**
      * @return bool
      */
-    public function isCanSetStickerSet()
+    public function getCanSetStickerSet()
     {
         return $this->canSetStickerSet;
     }
@@ -514,5 +516,149 @@ class Chat extends BaseType implements TypeInterface
     public function setLocation($location)
     {
         $this->location = $location;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getJoinToSendMessages()
+    {
+        return $this->joinToSendMessages;
+    }
+
+    /**
+     * @param bool $joinToSendMessages
+     */
+    public function setJoinToSendMessages($joinToSendMessages)
+    {
+        $this->joinToSendMessages = $joinToSendMessages;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getJoinByRequest()
+    {
+        return $this->joinByRequest;
+    }
+
+    /**
+     * @param bool $joinByRequest
+     */
+    public function setJoinByRequest($joinByRequest)
+    {
+        $this->joinByRequest = $joinByRequest;
+    }
+
+    /**
+     * @return int
+     */
+    public function getMessageAutoDeleteTime()
+    {
+        return $this->messageAutoDeleteTime;
+    }
+
+    /**
+     * @param int $messageAutoDeleteTime
+     */
+    public function setMessageAutoDeleteTime($messageAutoDeleteTime)
+    {
+        $this->messageAutoDeleteTime = $messageAutoDeleteTime;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getHasProtectedContent()
+    {
+        return $this->hasProtectedContent;
+    }
+
+    /**
+     * @param bool $hasProtectedContent
+     */
+    public function setHasProtectedContent($hasProtectedContent)
+    {
+        $this->hasProtectedContent = $hasProtectedContent;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIsForum()
+    {
+        return $this->isForum;
+    }
+
+    /**
+     * @param bool $isForum
+     */
+    public function setIsForum($isForum)
+    {
+        $this->isForum = $isForum;
+    }
+
+    /**
+     * @return array
+     */
+    public function getActiveUsernames()
+    {
+        return $this->activeUsernames;
+    }
+
+    /**
+     * @param array $activeUsernames
+     */
+    public function setActiveUsernames($activeUsernames)
+    {
+        $this->activeUsernames = $activeUsernames;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getEmojiStatusCustomEmojiId()
+    {
+        return $this->emojiStatusCustomEmojiId;
+    }
+
+    /**
+     * @param bool $emojiStatusCustomEmojiId
+     */
+    public function setEmojiStatusCustomEmojiId($emojiStatusCustomEmojiId)
+    {
+        $this->emojiStatusCustomEmojiId = $emojiStatusCustomEmojiId;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getHasPrivateForwards()
+    {
+        return $this->hasPrivateForwards;
+    }
+
+    /**
+     * @param bool $hasPrivateForwards
+     */
+    public function setHasPrivateForwards($hasPrivateForwards)
+    {
+        $this->hasPrivateForwards = $hasPrivateForwards;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getHasRestrictedVoiceAndVideoMessages()
+    {
+        return $this->hasRestrictedVoiceAndVideoMessages;
+    }
+
+    /**
+     * @param bool $hasRestrictedVoiceAndVideoMessages
+     */
+    public function setHasRestrictedVoiceAndVideoMessages($hasRestrictedVoiceAndVideoMessages)
+    {
+        $this->hasRestrictedVoiceAndVideoMessages = $hasRestrictedVoiceAndVideoMessages;
     }
 }

--- a/src/Types/Chat.php
+++ b/src/Types/Chat.php
@@ -37,7 +37,16 @@ class Chat extends BaseType implements TypeInterface
         'sticker_set_name' => true,
         'can_set_sticker_set' => true,
         'linked_chat_id' => true,
-        'location' => ChatLocation::class
+        'location' => ChatLocation::class,
+        'join_to_send_messages' => true,
+        'join_by_request' => true,
+        'message_auto_delete_time' => true,
+        'has_protected_content' => true,
+        'is_forum' => true,
+        'active_usernames' => true,
+        'emoji_status_custom_emoji_id' => true,
+        'has_private_forwards' => true,
+        'has_restricted_voice_and_video_messages' => true,
     ];
 
     /**
@@ -162,6 +171,72 @@ class Chat extends BaseType implements TypeInterface
      * @var ChatLocation
      */
     protected $location;
+
+    /**
+     * Optional. True, if users need to join the supergroup before they can send messages. Returned only in getChat.
+     *
+     * @var bool
+     */
+    protected $joinToSendMessages;
+
+    /**
+     * Optional. True, if all users directly joining the supergroup need to be approved by supergroup administrators. Returned only in getChat.
+     *
+     * @var bool
+     */
+    protected $joinByRequest;
+
+    /**
+     * Optional. Time after which all messages sent to the chat will be automatically deleted; in seconds. Returned
+     * only in getChat.
+     *
+     * @var int
+     */
+    protected $messageAutoDeleteTime;
+
+    /**
+     * Optional. True, if the chat has a custom title. Returned only in getChat.
+     *
+     * @var bool
+     */
+    protected $hasProtectedContent;
+
+    /**
+     * Optional. True, if the chat is a forum. Returned only in getChat.
+     *
+     * @var bool
+     */
+    protected $isForum;
+
+    /**
+     * Optional. True, if the chat is a forum. Returned only in getChat.
+     *
+     * @var array[]
+     */
+    protected $activeUsernames;
+
+    /**
+     * Optional. True, if the chat is a forum. Returned only in getChat.
+     *
+     * @var bool
+     */
+    protected $emojiStatusCustomEmojiId;
+
+    /**
+     * Optional. True, if the chat is a forum. Returned only in getChat.
+     *
+     * @var bool
+     */
+    protected $hasPrivateForwards;
+
+    /**
+     * Optional. True, if the chat is a forum. Returned only in getChat.
+     *
+     * @var bool
+     */
+    protected $hasRestrictedVoiceAndVideoMessages;
+
+
 
     /**
      * @return int|string

--- a/src/Types/ChatMember.php
+++ b/src/Types/ChatMember.php
@@ -34,7 +34,12 @@ class ChatMember extends BaseType
         'can_send_messages' => true,
         'can_send_media_messages' => true,
         'can_send_other_messages' => true,
-        'can_add_web_page_previews' => true
+        'can_add_web_page_previews' => true,
+        'can_manage_topics' => true,
+        'is_anonymous' => true,
+        'custom_title' => true,
+        'can_manage_chat' => true,
+        'can_send_polls' => true,
     ];
 
     /**
@@ -52,7 +57,7 @@ class ChatMember extends BaseType
     protected $status;
 
     /**
-     * Optional. Restictred and kicked only. Date when restrictions will be lifted for this user, unix time
+     * Optional. Restricted and kicked only. Date when restrictions will be lifted for this user, unix time
      *
      * @var integer
      */
@@ -153,6 +158,43 @@ class ChatMember extends BaseType
      * @var bool
      */
     protected $canAddWebPagePreviews;
+
+    /**
+     * Optional. True, if the user is allowed to create, rename, close, and reopen forum topics; supergroups only
+     *
+     * @var bool
+     */
+    protected $canManageTopics;
+
+    /**
+     * True, if the user's presence in the chat is hidden
+     *
+     * @var bool
+     */
+    protected $isAnonymous;
+
+    /**
+     * Optional. Custom title for this user
+     *
+     * @var string
+     */
+    protected $customTitle;
+
+    /**
+     * True, if the administrator can access the chat event log, chat statistics, message statistics in channels,
+     * see channel members, see anonymous administrators in supergroups and ignore slow mode.
+     * Implied by any other administrator privilege
+     *
+     * @var bool
+     */
+    protected $canManageChat;
+
+    /**
+     * True, if the user is allowed to send polls
+     *
+     * @var bool
+     */
+    protected $canSendPolls;
 
     /**
      * @return User
@@ -408,5 +450,85 @@ class ChatMember extends BaseType
     public function setCanAddWebPagePreviews($canAddWebPagePreviews)
     {
         $this->canAddWebPagePreviews = $canAddWebPagePreviews;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getCanManageChat()
+    {
+        return $this->canManageChat;
+    }
+
+    /**
+     * @param bool $canManageChat
+     */
+    public function setCanManageChat($canManageChat)
+    {
+        $this->canManageChat = $canManageChat;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIsAnonymous()
+    {
+        return $this->isAnonymous;
+    }
+
+    /**
+     * @param bool $isAnonymous
+     */
+    public function setIsAnonymous($isAnonymous)
+    {
+        $this->isAnonymous = $isAnonymous;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getCanSendPolls()
+    {
+        return $this->canSendPolls;
+    }
+
+    /**
+     * @param bool $canSendPolls
+     */
+    public function setCanSendPolls($canSendPolls)
+    {
+        $this->canSendPolls = $canSendPolls;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getCanManageTopics()
+    {
+        return $this->canManageTopics;
+    }
+
+    /**
+     * @param bool $canManageTopics
+     */
+    public function setCanManageTopics($canManageTopics)
+    {
+        $this->canManageTopics = $canManageTopics;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCustomTitle()
+    {
+        return $this->customTitle;
+    }
+
+    /**
+     * @param string $customTitle
+     */
+    public function setCustomTitle($customTitle)
+    {
+        $this->customTitle = $customTitle;
     }
 }

--- a/src/Types/Document.php
+++ b/src/Types/Document.php
@@ -22,6 +22,7 @@ class Document extends BaseType implements TypeInterface
      */
     static protected $map = [
         'file_id' => true,
+        'file_unique_id' => true,
         'thumb' => PhotoSize::class,
         'file_name' => true,
         'mime_type' => true,
@@ -69,6 +70,13 @@ class Document extends BaseType implements TypeInterface
      * @var int
      */
     protected $fileSize;
+
+    /**
+     * Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+     *
+     * @var string
+     */
+    protected $fileUniqueId;
 
     /**
      * @return string
@@ -154,5 +162,21 @@ class Document extends BaseType implements TypeInterface
     public function setThumb(PhotoSize $thumb)
     {
         $this->thumb = $thumb;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFileUniqueId()
+    {
+        return $this->fileUniqueId;
+    }
+
+    /**
+     * @param string $fileUniqueId
+     */
+    public function setFileUniqueId($fileUniqueId)
+    {
+        $this->fileUniqueId = $fileUniqueId;
     }
 }

--- a/src/Types/File.php
+++ b/src/Types/File.php
@@ -31,6 +31,7 @@ class File extends BaseType implements TypeInterface
      */
     static protected $map = [
         'file_id' => true,
+        'file_unique_id' => true,
         'file_size' => true,
         'file_path' => true
     ];
@@ -55,6 +56,13 @@ class File extends BaseType implements TypeInterface
      * @var string
      */
     protected $filePath;
+
+    /**
+     * Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+     *
+     * @var string
+     */
+    protected $fileUniqueId;
 
     /**
      * @return string
@@ -108,5 +116,21 @@ class File extends BaseType implements TypeInterface
     public function setFilePath($filePath)
     {
         $this->filePath = $filePath;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFileUniqueId()
+    {
+        return $this->fileUniqueId;
+    }
+
+    /**
+     * @param string $fileUniqueId
+     */
+    public function setFileUniqueId($fileUniqueId)
+    {
+        $this->fileUniqueId = $fileUniqueId;
     }
 }

--- a/src/Types/ForumTopic.php
+++ b/src/Types/ForumTopic.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace TelegramBot\Api\Types;
+
+use TelegramBot\Api\BaseType;
+use TelegramBot\Api\TypeInterface;
+
+/**
+ * Class ForumTopic
+ * This object represents a forum topic.
+ *
+ * @package TelegramBot\Api\Types
+ * @author bernard-ng <bernard@devscast.tech>
+ */
+class ForumTopic extends BaseType implements TypeInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @var array
+     */
+    protected static $requiredParams = ['message_thread_id', 'name', 'icon_color'];
+
+    /**
+     * {@inheritdoc}
+     *
+     * @var array
+     */
+    protected static $map = [
+        'message_thread_id' => true,
+        'name' => true,
+        'icon_color' => true,
+        'icon_custom_emoji_id' => true,
+    ];
+
+    /**
+     * Unique identifier of the forum topic
+     *
+     * @var int
+     */
+    protected $messageThreadId;
+
+    /**
+     * Name of the topic
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * Color of the topic icon in RGB format
+     *
+     * @var int
+     */
+    protected $iconColor;
+
+    /**
+     * Optional. Unique identifier of the custom emoji shown as the topic icon
+     *
+     * @var string
+     */
+    protected $iconCustomEmojiId;
+
+    /**
+     * @return int
+     */
+    public function getMessageThreadId()
+    {
+        return $this->messageThreadId;
+    }
+
+    /**
+     * @param int $messageThreadId
+     */
+    public function setMessageThreadId($messageThreadId)
+    {
+        $this->messageThreadId = $messageThreadId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return int
+     */
+    public function getIconColor()
+    {
+        return $this->iconColor;
+    }
+
+    /**
+     * @param int $iconColor
+     */
+    public function setIconColor($iconColor)
+    {
+        $this->iconColor = $iconColor;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIconCustomEmojiId()
+    {
+        return $this->iconCustomEmojiId;
+    }
+
+    /**
+     * @param string $iconCustomEmojiId
+     */
+    public function setIconCustomEmojiId($iconCustomEmojiId)
+    {
+        $this->iconCustomEmojiId = $iconCustomEmojiId;
+    }
+}

--- a/src/Types/ForumTopicClosed.php
+++ b/src/Types/ForumTopicClosed.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace TelegramBot\Api\Types;
+
+use TelegramBot\Api\BaseType;
+use TelegramBot\Api\TypeInterface;
+
+/**
+ * Class ForumTopicClosed
+ * This object represents a service message about a forum topic closed in the chat. Currently holds no information.
+ *
+ * @package TelegramBot\Api\Types
+ * @author bernard-ng <bernard@devscast.tech>
+ */
+class ForumTopicClosed extends BaseType implements TypeInterface
+{
+}

--- a/src/Types/ForumTopicCreated.php
+++ b/src/Types/ForumTopicCreated.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace TelegramBot\Api\Types;
+
+use TelegramBot\Api\BaseType;
+use TelegramBot\Api\TypeInterface;
+
+/**
+ * class ForumTopicCreated.
+ * This object represents a service message about a new forum topic created in the chat.
+ *
+ * @package TelegramBot\Api\Types
+ * @author bernard-ng <bernard@devscast.tech>
+ */
+class ForumTopicCreated extends BaseType implements TypeInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @var array
+     */
+    protected static $requiredParams = ['name', 'icon_color'];
+
+    /**
+     * {@inheritdoc}
+     *
+     * @var array
+     */
+    protected static $map = [
+        'name' => true,
+        'icon_color' => true,
+        'icon_custom_emoji_id' => true,
+    ];
+
+    /**
+     * Name of the forum topic
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * Color of the forum topic
+     *
+     * @var string
+     */
+    protected $iconColor;
+
+    /**
+     * Custom emoji of the forum topic
+     *
+     * @var string
+     */
+    protected $iconCustomEmojiId;
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIconColor()
+    {
+        return $this->iconColor;
+    }
+
+    /**
+     * @param string $iconColor
+     */
+    public function setIconColor($iconColor)
+    {
+        $this->iconColor = $iconColor;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIconCustomEmojiId()
+    {
+        return $this->iconCustomEmojiId;
+    }
+
+    /**
+     * @param string $iconCustomEmojiId
+     */
+    public function setIconCustomEmojiId($iconCustomEmojiId)
+    {
+        $this->iconCustomEmojiId = $iconCustomEmojiId;
+    }
+}

--- a/src/Types/ForumTopicReopened.php
+++ b/src/Types/ForumTopicReopened.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace TelegramBot\Api\Types;
+
+use TelegramBot\Api\BaseType;
+use TelegramBot\Api\TypeInterface;
+
+/**
+ * Class ForumTopicReopened
+ * This object represents a service message about a forum topic reopened in the chat. Currently holds no information.
+ *
+ * @package TelegramBot\Api\Types
+ * @author bernard-ng <bernard@devscast.tech>
+ */
+class ForumTopicReopened extends BaseType implements TypeInterface
+{
+}

--- a/src/Types/MaskPosition.php
+++ b/src/Types/MaskPosition.php
@@ -10,7 +10,110 @@ use TelegramBot\Api\TypeInterface;
  * This object describes the position on faces where a mask should be placed by default.
  *
  * @package TelegramBot\Api\Types
+ * @author bernard-ng <bernard@devscast.tech>
  */
 class MaskPosition extends BaseType implements TypeInterface
 {
+    protected static $requiredParams = ['point', 'x_shift', 'y_shift', 'scale'];
+
+    protected static $map = [
+        'point' => true,
+        'x_shift' => true,
+        'y_shift' => true,
+        'scale' => true,
+    ];
+
+    /**
+     * The part of the face relative to which the mask should be placed. One of “forehead”, “eyes”, “mouth”, or “chin”.
+     *
+     * @var string
+     */
+    protected $point;
+
+    /**
+     * Shift by X-axis measured in widths of the mask scaled to the face size, from left to right.
+     * For example, choosing -1.0 will place mask just to the left of the default mask position.
+     *
+     * @var float
+     */
+    protected $xShift;
+
+    /**
+     * Shift by Y-axis measured in heights of the mask scaled to the face size, from top to bottom.
+     * For example, 1.0 will place the mask just below the default mask position.
+     *
+     * @var float
+     */
+    protected $yShift;
+
+    /**
+     * Mask scaling coefficient. For example, 2.0 means double size.
+     *
+     * @var float
+     */
+    protected $scale;
+
+    /**
+     * @return string
+     */
+    public function getPoint()
+    {
+        return $this->point;
+    }
+
+    /**
+     * @param string $point
+     */
+    public function setPoint($point)
+    {
+        $this->point = $point;
+    }
+
+    /**
+     * @return float
+     */
+    public function getXShift()
+    {
+        return $this->xShift;
+    }
+
+    /**
+     * @param float $xShift
+     */
+    public function setXShift($xShift)
+    {
+        $this->xShift = $xShift;
+    }
+
+    /**
+     * @return float
+     */
+    public function getYShift()
+    {
+        return $this->yShift;
+    }
+
+    /**
+     * @param float $yShift
+     */
+    public function setYShift($yShift)
+    {
+        $this->yShift = $yShift;
+    }
+
+    /**
+     * @return float
+     */
+    public function getScale()
+    {
+        return $this->scale;
+    }
+
+    /**
+     * @param float $scale
+     */
+    public function setScale($scale)
+    {
+        $this->scale = $scale;
+    }
 }

--- a/src/Types/MaskPosition.php
+++ b/src/Types/MaskPosition.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TelegramBot\Api\Types;
+
+use TelegramBot\Api\BaseType;
+use TelegramBot\Api\TypeInterface;
+
+/**
+ * Class MaskPosition
+ * This object describes the position on faces where a mask should be placed by default.
+ *
+ * @package TelegramBot\Api\Types
+ */
+class MaskPosition extends BaseType implements TypeInterface
+{
+}

--- a/src/Types/Message.php
+++ b/src/Types/Message.php
@@ -68,6 +68,11 @@ class Message extends BaseType implements TypeInterface
         'invoice' => Invoice::class,
         'successful_payment' => SuccessfulPayment::class,
         'connected_website' => true,
+        'forum_topic_created' => ForumTopicCreated::class,
+        'forum_topic_closed' => ForumTopicClosed::class,
+        'forum_topic_reopened' => ForumTopicReopened::class,
+        'is_topic_message' => true,
+        'message_thread_id' => true,
     ];
 
     /**
@@ -404,6 +409,42 @@ class Message extends BaseType implements TypeInterface
      * @var InlineKeyboardMarkup
      */
     protected $replyMarkup;
+
+    /**
+     * Optional. Service message: forum topic created
+     *
+     * @var ForumTopicCreated
+     */
+    protected $forumTopicCreated;
+
+    /**
+     * Optional. Service message: forum topic closed
+     *
+     * @var ForumTopicReopened
+     */
+    protected $forumTopicReopened;
+
+    /**
+     * Optional. Service message: forum topic reopened
+     *
+     * @var ForumTopicClosed
+     */
+    protected $forumTopicClosed;
+
+    /**
+     * Optional. True, if the message is sent to a forum topic
+     *
+     * @var bool
+     */
+    protected $isTopicMessage;
+
+    /**
+     * Optional. Unique identifier of a message thread to which the message belongs; for supergroups only
+     *
+     * @var int
+     */
+    protected $messageThreadId;
+
 
     /**
      * @return int
@@ -1167,5 +1208,85 @@ class Message extends BaseType implements TypeInterface
     public function setReplyMarkup($replyMarkup)
     {
         $this->replyMarkup = $replyMarkup;
+    }
+
+    /**
+     * @return ForumTopicCreated
+     */
+    public function getForumTopicCreated()
+    {
+        return $this->forumTopicCreated;
+    }
+
+    /**
+     * @param ForumTopicCreated $forumTopicCreated
+     */
+    public function setForumTopicCreated($forumTopicCreated)
+    {
+        $this->forumTopicCreated = $forumTopicCreated;
+    }
+
+    /**
+     * @return ForumTopicClosed
+     */
+    public function getForumTopicClosed()
+    {
+        return $this->forumTopicClosed;
+    }
+
+    /**
+     * @param ForumTopicClosed $forumTopicClosed
+     */
+    public function setForumTopicClosed($forumTopicClosed)
+    {
+        $this->forumTopicClosed = $forumTopicClosed;
+    }
+
+    /**
+     * @return ForumTopicReopened
+     */
+    public function getForumTopicReopened()
+    {
+        return $this->forumTopicReopened;
+    }
+
+    /**
+     * @param ForumTopicReopened $forumTopicReopened
+     */
+    public function setForumTopicReopened($forumTopicReopened)
+    {
+        $this->forumTopicReopened = $forumTopicReopened;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIsTopicMessage()
+    {
+        return $this->isTopicMessage;
+    }
+
+    /**
+     * @param bool $isTopicMessage
+     */
+    public function setIsTopicMessage($isTopicMessage)
+    {
+        $this->isTopicMessage = $isTopicMessage;
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getMessageThreadId()
+    {
+        return $this->messageThreadId;
+    }
+
+    /**
+     * @param int|null $messageThreadId
+     */
+    public function setMessageThreadId($messageThreadId)
+    {
+        $this->messageThreadId = $messageThreadId;
     }
 }

--- a/src/Types/MessageEntity.php
+++ b/src/Types/MessageEntity.php
@@ -11,6 +11,11 @@ namespace TelegramBot\Api\Types;
 use TelegramBot\Api\BaseType;
 use TelegramBot\Api\TypeInterface;
 
+/**
+ * class MessageEntity.
+ *
+ * @author bernard-ng <bernard@devscast.tech>
+ */
 class MessageEntity extends BaseType implements TypeInterface
 {
 
@@ -29,6 +34,7 @@ class MessageEntity extends BaseType implements TypeInterface
     const TYPE_PRE = 'pre';
     const TYPE_TEXT_LINK = 'text_link';
     const TYPE_TEXT_MENTION = 'text_mention';
+    const TYPE_CUSTOM_EMOJI = 'custom_emoji';
 
     /**
      * {@inheritdoc}
@@ -49,6 +55,7 @@ class MessageEntity extends BaseType implements TypeInterface
         'url' => true,
         'user' => User::class,
         'language' => true,
+        'custom_emoji_id' => true,
     ];
 
     /**
@@ -96,6 +103,14 @@ class MessageEntity extends BaseType implements TypeInterface
      * @var string
      */
     protected $language;
+
+    /**
+     * Optional. For “custom_emoji” only, unique identifier of the custom emoji.
+     * Use getCustomEmojiStickers to get full information about the sticker
+     *
+     * @var string
+     */
+    protected $custom_emoji_id;
 
     /**
      * @return string
@@ -191,5 +206,21 @@ class MessageEntity extends BaseType implements TypeInterface
     public function setLanguage($language)
     {
         $this->language = $language;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCustomEmojiId()
+    {
+        return $this->custom_emoji_id;
+    }
+
+    /**
+     * @param string $custom_emoji_id
+     */
+    public function setCustomEmojiId($custom_emoji_id)
+    {
+        $this->custom_emoji_id = $custom_emoji_id;
     }
 }

--- a/src/Types/PhotoSize.php
+++ b/src/Types/PhotoSize.php
@@ -19,7 +19,7 @@ class PhotoSize extends BaseType implements TypeInterface
      *
      * @var array
      */
-    static protected $requiredParams = ['file_id', 'width', 'height'];
+    static protected $requiredParams = ['file_id', 'file_unique_id', 'width', 'height'];
 
     /**
      * {@inheritdoc}
@@ -28,6 +28,7 @@ class PhotoSize extends BaseType implements TypeInterface
      */
     static protected $map = [
         'file_id' => true,
+        'file_unique_id' => true,
         'width' => true,
         'height' => true,
         'file_size' => true,
@@ -60,6 +61,13 @@ class PhotoSize extends BaseType implements TypeInterface
      * @var int
      */
     protected $fileSize;
+
+    /**
+     * Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+     *
+     * @var string
+     */
+    protected $fileUniqueId;
 
     /**
      * @return string
@@ -141,5 +149,21 @@ class PhotoSize extends BaseType implements TypeInterface
         } else {
             throw new InvalidArgumentException();
         }
+    }
+
+    /**
+     * @return string
+     */
+    public function getFileUniqueId()
+    {
+        return $this->fileUniqueId;
+    }
+
+    /**
+     * @param string $fileUniqueId
+     */
+    public function setFileUniqueId($fileUniqueId)
+    {
+        $this->fileUniqueId = $fileUniqueId;
     }
 }

--- a/src/Types/Sticker.php
+++ b/src/Types/Sticker.php
@@ -19,7 +19,15 @@ class Sticker extends BaseType implements TypeInterface
      *
      * @var array
      */
-    static protected $requiredParams = ['file_id', 'width', 'height'];
+    static protected $requiredParams = [
+        'file_id',
+        'file_unique_id',
+        'type',
+        'width',
+        'height',
+        'is_animated',
+        'is_video'
+    ];
 
     /**
      * {@inheritdoc}
@@ -32,6 +40,15 @@ class Sticker extends BaseType implements TypeInterface
         'height' => true,
         'thumb' => PhotoSize::class,
         'file_size' => true,
+        'type' => true,
+        'file_unique_id' => true,
+        'premium_animation' => true,
+        'is_animated' => true,
+        'is_video' => true,
+        'emoji' => true,
+        'set_name' => true,
+        'mask_position' => MaskPosition::class,
+        'custom_emoji_id' => true,
     ];
 
     /**
@@ -56,7 +73,7 @@ class Sticker extends BaseType implements TypeInterface
     protected $height;
 
     /**
-     * Document thumbnail as defined by sender
+     * 	Optional. Sticker thumbnail in the .WEBP or .JPG format
      *
      * @var PhotoSize
      */
@@ -68,6 +85,72 @@ class Sticker extends BaseType implements TypeInterface
      * @var int
      */
     protected $fileSize;
+
+    /**
+     * Type of the sticker, currently one of “regular”, “mask”, “custom_emoji”.
+     * The type of the sticker is independent from its format,
+     * which is determined by the fields is_animated and is_video.
+     *
+     * @var string
+     */
+    protected $type;
+
+    /**
+     * Unique identifier for this file, which is supposed to be the same over time and for different bots.
+     * Can't be used to download or reuse the file.
+     *
+     * @var string
+     */
+    protected $fileUniqueId;
+
+    /**
+     * Optional. For premium regular stickers, premium animation for the sticker
+     *
+     * @var File
+     */
+    protected $premiumAnimation;
+
+    /**
+     * True, if the sticker is animated
+     *
+     * @var bool
+     */
+    protected $isAnimated;
+
+    /**
+     * True, if the sticker is a video sticker
+     *
+     * @var bool
+     */
+    protected $isVideo;
+
+    /**
+     * Optional. Emoji associated with the sticker
+     *
+     * @var string
+     */
+    protected $emoji;
+
+    /**
+     * Optional. Name of the sticker set to which the sticker belongs
+     *
+     * @var string
+     */
+    protected $setName;
+
+    /**
+     * Optional. For mask stickers, the position where the mask should be placed
+     *
+     * @var MaskPosition
+     */
+    protected $maskPosition;
+
+    /**
+     * Optional. For custom emoji stickers, unique identifier of the custom emoji
+     *
+     * @var string
+     */
+    protected $customEmojiId;
 
     /**
      * @return string
@@ -165,5 +248,149 @@ class Sticker extends BaseType implements TypeInterface
         } else {
             throw new InvalidArgumentException();
         }
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @param string $type
+     */
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFileUniqueId()
+    {
+        return $this->fileUniqueId;
+    }
+
+    /**
+     * @param string $fileUniqueId
+     */
+    public function setFileUniqueId($fileUniqueId)
+    {
+        $this->fileUniqueId = $fileUniqueId;
+    }
+
+    /**
+     * @return File
+     */
+    public function getPremiumAnimation()
+    {
+        return $this->premiumAnimation;
+    }
+
+    /**
+     * @param File $premiumAnimation
+     */
+    public function setPremiumAnimation(File $premiumAnimation)
+    {
+        $this->premiumAnimation = $premiumAnimation;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIsAnimated()
+    {
+        return $this->isAnimated;
+    }
+
+    /**
+     * @param bool $isAnimated
+     */
+    public function setIsAnimated($isAnimated)
+    {
+        $this->isAnimated = $isAnimated;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIsVideo()
+    {
+        return $this->isVideo;
+    }
+
+    /**
+     * @param bool $isVideo
+     */
+    public function setIsVideo($isVideo)
+    {
+        $this->isVideo = $isVideo;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEmoji()
+    {
+        return $this->emoji;
+    }
+
+    /**
+     * @param string $emoji
+     */
+    public function setEmoji($emoji)
+    {
+        $this->emoji = $emoji;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSetName()
+    {
+        return $this->setName;
+    }
+
+    /**
+     * @param string $setName
+     */
+    public function setSetName($setName)
+    {
+        $this->setName = $setName;
+    }
+
+    /**
+     * @return MaskPosition
+     */
+    public function getMaskPosition()
+    {
+        return $this->maskPosition;
+    }
+
+    /**
+     * @param MaskPosition $maskPosition
+     */
+    public function setMaskPosition(MaskPosition $maskPosition)
+    {
+        $this->maskPosition = $maskPosition;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCustomEmojiId()
+    {
+        return $this->customEmojiId;
+    }
+
+    /**
+     * @param string $customEmojiId
+     */
+    public function setCustomEmojiId($customEmojiId)
+    {
+        $this->customEmojiId = $customEmojiId;
     }
 }

--- a/src/Types/StickerSet.php
+++ b/src/Types/StickerSet.php
@@ -10,6 +10,7 @@ use TelegramBot\Api\TypeInterface;
  * This object represents a sticker set.
  *
  * @package TelegramBot\Api\Types
+ * @author bernard-ng <bernard@devscast.tech>
  */
 class StickerSet extends BaseType implements TypeInterface
 {

--- a/src/Types/StickerSet.php
+++ b/src/Types/StickerSet.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace TelegramBot\Api\Types;
+
+use TelegramBot\Api\BaseType;
+use TelegramBot\Api\TypeInterface;
+
+/**
+ * Class StickerSet
+ * This object represents a sticker set.
+ *
+ * @package TelegramBot\Api\Types
+ */
+class StickerSet extends BaseType implements TypeInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @var array
+     */
+    protected static $requiredParams = ['name', 'title', 'sticker_type', 'is_animated', 'is_video', 'stickers'];
+
+    /**
+     * {@inheritdoc}
+     *
+     * @var array
+     */
+    protected static $map = [
+        'name' => true,
+        'title' => true,
+        'sticker_type' => true,
+        'is_animated' => true,
+        'is_video' => true,
+        'stickers' => true,
+        'thumb' => true,
+    ];
+
+    /**
+     * Sticker set name
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * Sticker set title
+     *
+     * @var string
+     */
+    protected $title;
+
+    /**
+     * Type of stickers in the set, currently one of “regular”, “mask”, “custom_emoji”
+     *
+     * @var string
+     */
+    protected $stickerType;
+
+    /**
+     * True, if the sticker set contains animated stickers
+     *
+     * @var bool
+     */
+    protected $isAnimated;
+
+    /**
+     * True, if the sticker set contains video stickers
+     *
+     * @var bool
+     */
+    protected $isVideo;
+
+    /**
+     * List of all set stickers
+     *
+     * @var ArrayOfSticker
+     */
+    protected $stickers;
+
+    /**
+     * Optional. Sticker set thumbnail in the .WEBP or .TGS format
+     *
+     * @var PhotoSize
+     */
+    protected $thumb;
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTitle()
+    {
+        return $this->title;
+    }
+
+    /**
+     * @param string $title
+     */
+    public function setTitle($title)
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStickerType()
+    {
+        return $this->stickerType;
+    }
+
+    /**
+     * @param string $stickerType
+     */
+    public function setStickerType($stickerType)
+    {
+        $this->stickerType = $stickerType;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIsAnimated()
+    {
+        return $this->isAnimated;
+    }
+
+    /**
+     * @param bool $isAnimated
+     */
+    public function setIsAnimated($isAnimated)
+    {
+        $this->isAnimated = $isAnimated;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIsVideo()
+    {
+        return $this->isVideo;
+    }
+
+    /**
+     * @param bool $isVideo
+     */
+    public function setIsVideo($isVideo)
+    {
+        $this->isVideo = $isVideo;
+    }
+
+    /**
+     * @return ArrayOfSticker
+     */
+    public function getStickers()
+    {
+        return $this->stickers;
+    }
+
+    /**
+     * @param ArrayOfSticker $stickers
+     */
+    public function setStickers($stickers)
+    {
+        $this->stickers = $stickers;
+    }
+
+    /**
+     * @return PhotoSize
+     */
+    public function getThumb()
+    {
+        return $this->thumb;
+    }
+
+    /**
+     * @param PhotoSize $thumb
+     */
+    public function setThumb($thumb)
+    {
+        $this->thumb = $thumb;
+    }
+}

--- a/src/Types/User.php
+++ b/src/Types/User.php
@@ -32,6 +32,11 @@ class User extends BaseType implements TypeInterface
         'last_name' => true,
         'username' => true,
         'language_code' => true,
+        'is_premium' => true,
+        'added_to_attachment_menu' => true,
+        'can_join_groups' => true,
+        'can_read_all_group_messages' => true,
+        'supports_inline_queries' => true,
         'is_bot' => true
     ];
 
@@ -76,6 +81,41 @@ class User extends BaseType implements TypeInterface
      * @var bool
      */
     protected $isBot;
+
+    /**
+     * Optional. True, if this user is a Telegram Premium user
+     *
+     * @var bool
+     */
+    private $isPremium;
+
+    /**
+     * Optional. True, if this user added the bot to the attachment menu
+     *
+     * @var bool
+     */
+    private $addedToAttachmentMenu;
+
+    /**
+     * Optional. True, if the bot can be invited to groups. Returned only in getMe.
+     *
+     * @var bool
+     */
+    private $canJoinGroups;
+
+    /**
+     * Optional. True, if privacy mode is disabled for the bot. Returned only in getMe.
+     *
+     * @var bool
+     */
+    private $canReadAllGroupMessages;
+
+    /**
+     * Optional. True, if the bot supports inline queries. Returned only in getMe.
+     *
+     * @var bool
+     */
+    private $supportsInlineQueries;
 
     /**
      * @return string
@@ -177,5 +217,89 @@ class User extends BaseType implements TypeInterface
     public function setIsBot($isBot)
     {
         $this->isBot = $isBot;
+    }
+
+
+//'can_read_all_group_messages' => true,
+//'supports_inline_queries' => true,
+
+    /**
+     * @param bool $isPremium
+     */
+    public function setIsPremium($isPremium)
+    {
+        $this->isPremium = $isPremium;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIsPremium()
+    {
+        return $this->isPremium;
+    }
+
+    /**
+     * @param bool $addedToAttachmentMenu
+     */
+    public function setAddedToAttachmentMenu($addedToAttachmentMenu)
+    {
+        $this->addedToAttachmentMenu = $addedToAttachmentMenu;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getAddedToAttachmentMenu()
+    {
+        return $this->addedToAttachmentMenu;
+    }
+
+    /**
+     * @param bool $canJoinGroups
+     */
+    public function setCanJoinGroups($canJoinGroups)
+    {
+        $this->canJoinGroups = $canJoinGroups;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getCanJoinGroups()
+    {
+        return $this->canJoinGroups;
+    }
+
+    /**
+     * @param bool $canReadAllGroupMessages
+     */
+    public function setCanReadAllGroupMessages($canReadAllGroupMessages)
+    {
+        $this->canReadAllGroupMessages = $canReadAllGroupMessages;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getCanReadAllGroupMessages()
+    {
+        return $this->canReadAllGroupMessages;
+    }
+
+    /**
+     * @param bool $supportsInlineQueries
+     */
+    public function setSupportsInlineQueries($supportsInlineQueries)
+    {
+        $this->supportsInlineQueries = $supportsInlineQueries;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getSupportsInlineQueries()
+    {
+        return $this->supportsInlineQueries;
     }
 }

--- a/src/Types/Video.php
+++ b/src/Types/Video.php
@@ -19,7 +19,7 @@ class Video extends BaseType implements TypeInterface
      *
      * @var array
      */
-    static protected $requiredParams = ['file_id', 'width', 'height', 'duration'];
+    static protected $requiredParams = ['file_id', 'file_unique_id', 'width', 'height', 'duration'];
 
     /**
      * {@inheritdoc}
@@ -28,6 +28,7 @@ class Video extends BaseType implements TypeInterface
      */
     static protected $map = [
         'file_id' => true,
+        'file_unique_id' => true,
         'width' => true,
         'height' => true,
         'duration' => true,
@@ -85,6 +86,13 @@ class Video extends BaseType implements TypeInterface
      * @var int
      */
     protected $fileSize;
+
+    /**
+     * Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+     *
+     * @var string
+     */
+    protected $fileUniqueId;
 
     /**
      * @return int
@@ -220,5 +228,21 @@ class Video extends BaseType implements TypeInterface
         } else {
             throw new InvalidArgumentException();
         }
+    }
+
+    /**
+     * @return string
+     */
+    public function getFileUniqueId()
+    {
+        return $this->fileUniqueId;
+    }
+
+    /**
+     * @param string $fileUniqueId
+     */
+    public function setFileUniqueId($fileUniqueId)
+    {
+        $this->fileUniqueId = $fileUniqueId;
     }
 }

--- a/src/Types/VideoNote.php
+++ b/src/Types/VideoNote.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace TelegramBot\Api\Types;
+
+use TelegramBot\Api\BaseType;
+use TelegramBot\Api\TypeInterface;
+
+/**
+ * Class VideoNote
+ * This object represents a video message (available in Telegram apps as of v.4.0).
+ *
+ * @package TelegramBot\Api\Types
+ */
+class VideoNote extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['file_id', 'file_unique_id', 'length', 'duration'];
+
+    protected static $map = [
+        'file_id' => true,
+        'file_unique_id' => true,
+        'length' => true,
+        'duration' => true,
+        'thumb' => PhotoSize::class,
+        'file_size' => true,
+    ];
+
+    /**
+     * Unique identifier for this file
+     *
+     * @var string
+     */
+    protected $fileId;
+
+    /**
+     * Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+     *
+     * @var string
+     */
+    protected $fileUniqueId;
+
+    /**
+     * Video width and height (diameter of the video message) as defined by sender
+     *
+     * @var int
+     */
+    protected $length;
+
+    /**
+     * Duration of the video in seconds as defined by sender
+     *
+     * @var int
+     */
+    protected $duration;
+
+    /**
+     * Optional. Video thumbnail
+     *
+     * @var PhotoSize
+     */
+    protected $thumb;
+
+    /**
+     * Optional. File size in bytes
+     *
+     * @var int
+     */
+    protected $fileSize;
+
+    /**
+     * @return string
+     */
+    public function getFileId()
+    {
+        return $this->fileId;
+    }
+
+    /**
+     * @param string $fileId
+     */
+    public function setFileId($fileId)
+    {
+        $this->fileId = $fileId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFileUniqueId()
+    {
+        return $this->fileUniqueId;
+    }
+
+    /**
+     * @param string $fileUniqueId
+     */
+    public function setFileUniqueId($fileUniqueId)
+    {
+        $this->fileUniqueId = $fileUniqueId;
+    }
+
+    /**
+     * @return int
+     */
+    public function getLength()
+    {
+        return $this->length;
+    }
+
+    /**
+     * @param int $length
+     */
+    public function setLength($length)
+    {
+        $this->length = $length;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDuration()
+    {
+        return $this->duration;
+    }
+
+    /**
+     * @param int $duration
+     */
+    public function setDuration($duration)
+    {
+        $this->duration = $duration;
+    }
+
+    /**
+     * @return PhotoSize
+     */
+    public function getThumb()
+    {
+        return $this->thumb;
+    }
+
+    /**
+     * @param PhotoSize $thumb
+     */
+    public function setThumb($thumb)
+    {
+        $this->thumb = $thumb;
+    }
+
+    /**
+     * @return int
+     */
+    public function getFileSize()
+    {
+        return $this->fileSize;
+    }
+
+    /**
+     * @param int $fileSize
+     */
+    public function setFileSize($fileSize)
+    {
+        $this->fileSize = $fileSize;
+    }
+}

--- a/src/Types/WebhookInfo.php
+++ b/src/Types/WebhookInfo.php
@@ -33,8 +33,10 @@ class WebhookInfo extends BaseType implements TypeInterface
         'url' => true,
         'has_custom_certificate' => true,
         'pending_update_count' => true,
+        'ip_address' => true,
         'last_error_date' => true,
         'last_error_message' => true,
+        'last_synchronization_error_date' => true,
         'max_connections' => true,
         'allowed_updates' => true
     ];
@@ -61,6 +63,13 @@ class WebhookInfo extends BaseType implements TypeInterface
     protected $pendingUpdateCount;
 
     /**
+     * Optional. Currently used webhook IP address
+     *
+     * @var string
+     */
+    protected $ipAddress;
+
+    /**
      * Optional. Unix time for the most recent error that happened when trying to deliver an update via webhook
      *
      * @var int
@@ -74,6 +83,14 @@ class WebhookInfo extends BaseType implements TypeInterface
      * @var string
      */
     protected $lastErrorMessage;
+
+    /**
+     * Optional. Unix time of the most recent error that happened when trying to synchronize available updates
+     * with Telegram datacenters
+     *
+     * @var int
+     */
+    protected $lastSynchronizationErrorDate;
 
     /**
      * Optional. Maximum allowed number of simultaneous HTTPS connections to the webhook for update delivery
@@ -122,6 +139,22 @@ class WebhookInfo extends BaseType implements TypeInterface
     }
 
     /**
+     * @param string $ipAddress
+     */
+    public function setIpAddress($ipAddress)
+    {
+        $this->ipAddress = $ipAddress;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIpAddress()
+    {
+        return $this->ipAddress;
+    }
+
+    /**
      * @return int
      */
     public function getPendingUpdateCount()
@@ -167,6 +200,22 @@ class WebhookInfo extends BaseType implements TypeInterface
     public function setLastErrorMessage($lastErrorMessage)
     {
         $this->lastErrorMessage = $lastErrorMessage;
+    }
+
+    /**
+     * @param string $lastSynchronizationErrorDate
+     */
+    public function setLastSynchronizationErrorDate($lastSynchronizationErrorDate)
+    {
+        $this->lastSynchronizationErrorDate = $lastSynchronizationErrorDate;
+    }
+
+    /**
+     * @return int
+     */
+    public function getlastSynchronizationErrorDate()
+    {
+        return $this->lastSynchronizationErrorDate;
     }
 
     /**

--- a/tests/Types/MessageEntityTest.php
+++ b/tests/Types/MessageEntityTest.php
@@ -21,6 +21,7 @@ class MessageEntityTest extends \PHPUnit_Framework_TestCase
                 'username' => 'hunter',
                 'language_code' => 'en',
             ],
+            'custom_emoji_id' => 1,
         ]);
 
         $this->assertInstanceOf(MessageEntity::class, $messageEntity);
@@ -36,6 +37,7 @@ class MessageEntityTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('hunter', $messageEntity->getUser()->getUsername());
         $this->assertEquals('en', $messageEntity->getUser()->getLanguageCode());
         $this->assertNull($messageEntity->getLanguage());
+        $this->assertEquals(1, $messageEntity->getCustomEmojiId());
     }
 
     public function testPreFromResponse()

--- a/tests/UserTest.php
+++ b/tests/UserTest.php
@@ -84,13 +84,25 @@ class UserTest extends \PHPUnit_Framework_TestCase
             'first_name' => 'Ilya',
             'last_name' => 'Gusev',
             'id' => 123456,
-            'username' => 'iGusev'
+            'username' => 'iGusev',
+            'language_code' => 'en',
+            'is_premium' => false,
+            'added_to_attachment_menu' => false,
+            'can_join_groups' => true,
+            'can_read_all_group_messages' => true,
+            'supports_inline_queries' => false,
         ));
         $this->assertInstanceOf('\TelegramBot\Api\Types\User', $user);
         $this->assertEquals(123456, $user->getId());
         $this->assertEquals('Ilya', $user->getFirstName());
         $this->assertEquals('Gusev', $user->getLastName());
         $this->assertEquals('iGusev', $user->getUsername());
+        $this->assertEquals('en', $user->getLanguageCode());
+        $this->assertEquals(false, $user->getIsPremium());
+        $this->assertEquals(false, $user->getAddedToAttachmentMenu());
+        $this->assertEquals(true, $user->getCanJoinGroups());
+        $this->assertEquals(true, $user->getCanReadAllGroupMessages());
+        $this->assertEquals(false, $user->getSupportsInlineQueries());
     }
 
     /**

--- a/tests/WebhookInfoTest.php
+++ b/tests/WebhookInfoTest.php
@@ -17,8 +17,10 @@ class WebhookInfoTest extends \PHPUnit_Framework_TestCase
             'url' => '',
             'has_custom_certificate' => false,
             'pending_update_count' => 0,
+            'ip_address' => '',
             'last_error_date' => null,
             'last_error_message' => null,
+            'last_synchronization_error_date' => null,
             'max_connections' => 40,
             'allowed_updates' => null
         ));
@@ -26,8 +28,10 @@ class WebhookInfoTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('', $webhookInfo->getUrl());
         $this->assertEquals(false, $webhookInfo->hasCustomCertificate());
         $this->assertEquals(0, $webhookInfo->getPendingUpdateCount());
+        $this->assertEquals('', $webhookInfo->getipAddress());
         $this->assertEquals(null, $webhookInfo->getLastErrorDate());
         $this->assertEquals(null, $webhookInfo->getLastErrorMessage());
+        $this->assertEquals(null, $webhookInfo->getLastSynchronizationErrorDate());
         $this->assertEquals(40, $webhookInfo->getMaxConnections());
         $this->assertEquals(null, $webhookInfo->getAllowedUpdates());
     }


### PR DESCRIPTION
- Added support for [Topics in Groups](https://telegram.org/blog/topics-in-groups-collectible-usernames#topics-in-groups).
- Added the field is_forum to the class [Chat](https://core.telegram.org/bots/api#chat).
- Added the fields is_topic_message and message_thread_id to the class [Message](https://core.telegram.org/bots/api#message) to allow detection of messages belonging to a forum topic and their message thread identifier.
- Added the classes [ForumTopicCreated](https://core.telegram.org/bots/api#forumtopiccreated), [ForumTopicClosed](https://core.telegram.org/bots/api#forumtopicclosed), and [ForumTopicReopened](https://core.telegram.org/bots/api#forumtopicreopened) and the fields forum_topic_created, forum_topic_closed, and forum_topic_reopened to the class [Message](https://core.telegram.org/bots/api#message). Note that service messages about forum topic creation can't be deleted with the [deleteMessage](https://core.telegram.org/bots/api#deletemessage) method.

- Added the field can_manage_topics to the classes [ChatAdministratorRights](https://core.telegram.org/bots/api#chatadministratorrights), [ChatPermissions](https://core.telegram.org/bots/api#chatpermissions), [ChatMemberAdministrator](https://core.telegram.org/bots/api#chatmemberadministrator), and [ChatMemberRestricted](https://core.telegram.org/bots/api#chatmemberrestricted).

- Added the parameter can_manage_topics to the method [promoteChatMember](https://core.telegram.org/bots/api#promotechatmember).

- Added the methods [createForumTopic](https://core.telegram.org/bots/api#createforumtopic), [editForumTopic](https://core.telegram.org/bots/api#editforumtopic), [closeForumTopic](https://core.telegram.org/bots/api#closeforumtopic), [reopenForumTopic](https://core.telegram.org/bots/api#reopenforumtopic), [deleteForumTopic](https://core.telegram.org/bots/api#deleteforumtopic), [unpinAllForumTopicMessages](https://core.telegram.org/bots/api#unpinallforumtopicmessages), and [getForumTopicIconStickers](https://core.telegram.org/bots/api#getforumtopiciconstickers) for forum topic management.

- Added the parameter message_thread_id to the methods [sendMessage](https://core.telegram.org/bots/api#sendmessage), [sendPhoto](https://core.telegram.org/bots/api#sendphoto), [sendVideo](https://core.telegram.org/bots/api#sendvideo), [sendAnimation](https://core.telegram.org/bots/api#sendanimation), [sendAudio](https://core.telegram.org/bots/api#sendaudio), [sendDocument](https://core.telegram.org/bots/api#senddocument), [sendSticker](https://core.telegram.org/bots/api#sendsticker), [sendVideoNote](https://core.telegram.org/bots/api#sendvideonote), [sendVoice](https://core.telegram.org/bots/api#sendvoice), [sendLocation](https://core.telegram.org/bots/api#sendlocation), [sendVenue](https://core.telegram.org/bots/api#sendvenue), [sendContact](https://core.telegram.org/bots/api#sendcontact), [sendPoll](https://core.telegram.org/bots/api#sendpoll), [sendDice](https://core.telegram.org/bots/api#senddice), [sendInvoice](https://core.telegram.org/bots/api#sendinvoice), [sendGame](https://core.telegram.org/bots/api#sendgame), [sendMediaGroup](https://core.telegram.org/bots/api#sendmediagroup), [copyMessage](https://core.telegram.org/bots/api#copymessage), [forwardMessage](https://core.telegram.org/bots/api#forwardmessage) to support sending of messages to a forum topic.

- Added support for [Multiple Usernames](https://telegram.org/blog/topics-in-groups-collectible-usernames#collectible-usernames) via the field active_usernames in the class [Chat](https://core.telegram.org/bots/api#chat).

- Added the field emoji_status_custom_emoji_id to the class [Chat](https://core.telegram.org/bots/api#chat).

- Added the [MessageEntity](https://core.telegram.org/bots/api#messageentity) type “custom_emoji”.

- Added the field custom_emoji_id to the class [MessageEntity](https://core.telegram.org/bots/api#messageentity) for “custom_emoji” entities.
- Added the method [getCustomEmojiStickers](https://core.telegram.org/bots/api#getcustomemojistickers).
- Added the fields type and custom_emoji_id to the class [Sticker](https://core.telegram.org/bots/api#sticker).
- Added the field sticker_type to the class [StickerSet](https://core.telegram.org/bots/api#stickerset), describing the type of stickers in the set.
The field contains_masks has been removed from the documentation of the class [StickerSet](https://core.telegram.org/bots/api#stickerset). The field is still returned in the object for backward compatibility, but new bots should use the field sticker_type instead.
- Added the parameter sticker_type to the method [createNewStickerSet](https://core.telegram.org/bots/api#createnewstickerset).
The parameter contains_masks has been removed from the documentation of the method [createNewStickerSet](https://core.telegram.org/bots/api#createnewstickerset). The parameter will still work for backward compatibility, but new bots should use the parameter sticker_type instead.