### PR TITLE
Default value for $inlineKeyboard

### DIFF
--- a/src/Types/Inline/InlineKeyboardMarkup.php
+++ b/src/Types/Inline/InlineKeyboardMarkup.php
@@ -39,7 +39,7 @@ class InlineKeyboardMarkup extends BaseType
     /**
      * @param array $inlineKeyboard
      */
-    public function __construct($inlineKeyboard)
+    public function __construct($inlineKeyboard = [])
     {
         $this->inlineKeyboard = $inlineKeyboard;
     }


### PR DESCRIPTION
Default value for $inlineKeyboard to allow the constructor to be called with no arguments.

It because we have **Fatal error: Uncaught ArgumentCountError: Too few arguments to function TelegramBot\Api\Types\Inline\InlineKeyboardMarkup::__construct()** for this code (PHP 8.2):

```
$keyboard = new \TelegramBot\Api\Types\Inline\InlineKeyboardMarkup(
            [
                [
                    ['text' => 'link', 'url' => 'https://core.telegram.org/']
                ]
            ]
        );        
$bot->sendMessage($chatId, $messageText, null, false, null, $keyboard);
```