### PR TITLE
fix Animation type add file_unique_id field

### DIFF
--- a/src/Types/Animation.php
+++ b/src/Types/Animation.php
@@ -46,6 +46,13 @@ class Animation extends BaseType implements TypeInterface
     protected $fileId;
 
     /**
+     * Unique identifier for this file, which is supposed to be the same over time and for different bots. Can't be used to download or reuse the file.
+     *
+     * @var string
+     */
+    protected $fileUniqueId;
+
+    /**
      * Video width as defined by sender
      *
      * @var int
@@ -130,6 +137,22 @@ class Animation extends BaseType implements TypeInterface
     public function setFileId($fileId)
     {
         $this->fileId = $fileId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFileUniqueId()
+    {
+        return $this->fileUniqueId;
+    }
+
+    /**
+     * @param string $fileUniqueId
+     */
+    public function setFileUniqueId($fileUniqueId)
+    {
+        $this->fileUniqueId = $fileUniqueId;
     }
 
     /**


### PR DESCRIPTION
When I send an animation file, it throws an error "`Call to undefined method TelegramBot\Api\Types\Animation::setFileUniqueId()`".
I figured out that the "`file_unique_id`" field is absent in the class `Types/Animation.php`.
So I added It.