### PR TITLE
fix json_encode in BotApi class setMyCommands method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     ],
     "require": {
         "php" : ">=5.5.0",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit" : "~4.0",

--- a/src/Types/BotCommand.php
+++ b/src/Types/BotCommand.php
@@ -2,10 +2,11 @@
 
 namespace TelegramBot\Api\Types;
 
+use JsonSerializable;
 use TelegramBot\Api\BaseType;
 use TelegramBot\Api\TypeInterface;
 
-class BotCommand extends BaseType implements TypeInterface
+class BotCommand extends BaseType implements TypeInterface, JsonSerializable
 {
     /**
      * {@inheritdoc}
@@ -68,5 +69,13 @@ class BotCommand extends BaseType implements TypeInterface
     public function setDescription($description)
     {
         $this->description = $description;
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            'command' => $this->command,
+            'description' => $this->description,
+        ];
     }
 }

--- a/src/Types/BotCommand.php
+++ b/src/Types/BotCommand.php
@@ -71,6 +71,9 @@ class BotCommand extends BaseType implements TypeInterface, JsonSerializable
         $this->description = $description;
     }
 
+    /**
+     * @return array
+     */
     public function jsonSerialize()
     {
         return [


### PR DESCRIPTION
I noticed that in the `BotApi` class, an error occurs in the `setMyCommands` method when the code executes `json_encode($commands)`, returning empty objects in JSON and causing a BadRequest error from the Telegram API. To fix this error, I added implements of the `JsonSerializable` interface to the `BotCommand` class. Now when we call `json_encode($commands)` we get valid JSON.