### PR TITLE
added $fileUniqueId property Animation class

### DIFF
--- a/src/Types/Animation.php
+++ b/src/Types/Animation.php
@@ -39,11 +39,18 @@ class Animation extends BaseType implements TypeInterface
     ];
 
     /**
-     * Unique file identifier
+     * File identifier
      *
      * @var string
      */
     protected $fileId;
+
+    /**
+     * File unique identifier
+     *
+     * @var string
+     */
+    protected $fileUniqueId;
 
     /**
      * Video width as defined by sender
@@ -130,6 +137,22 @@ class Animation extends BaseType implements TypeInterface
     public function setFileId($fileId)
     {
         $this->fileId = $fileId;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFileUniqueId()
+    {
+        return $this->fileUniqueId;
+    }
+
+    /**
+     * @param string $fileUniqueId
+     */
+    public function setFileUniqueId($fileUniqueId)
+    {
+        $this->fileUniqueId = $fileUniqueId;
     }
 
     /**


### PR DESCRIPTION
When a GIF is sent to the bot, it breaks down. The error message reads: 
`Attempted to call an undefined method named 'setFileUniqueId' of class 'TelegramBot\Api\Types\Animation'. `

Upon inspecting the code, it was noticed that the `'file_unique_id'` was specified in the `Animation::$map`, causing `$method = 'set'.self::toCamelCase($key)` in the code to look for `setFileUniqueId`.