### PR TITLE
Add function and example allow run already defined command from callbackdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,58 +110,58 @@ try {
 #### Call to already added commands from callback data
 
 ```php
-require_once "vendor/autoload.php";
-
-try {
-    $bot = new \TelegramBot\Api\Client('YOUR_BOT_API_TOKEN');
-    // or initialize with botan.io tracker api key
-    // $bot = new \TelegramBot\Api\Client('YOUR_BOT_API_TOKEN', 'YOUR_BOTAN_TRACKER_API_KEY');
-
-    //Handle /ping command
-    $bot->command('ping', function ($message) use ($bot) {
-        $bot->sendMessage($message->getChat()->getId(), 'pong!');
-    });
-    
-    //Make test inline button
-    $bot->command('test_inline', function ($message) use ($bot) 
-	{
-		$userid = $message->getChat()->getId();
-					
-		$buttons = Array();
-		$buttons[] = array("text" => 'runping', "callback_data" => "command_/ping");
-					
-		$keyboard = new \TelegramBot\Api\Types\Inline\InlineKeyboardMarkup(array($buttons));
-					
-		$message = "✅ TEST INLINE.";
-		$bot->sendMessage($userid, $message, null, false, null, null, $keyboard);
-	});
-    
-    //Handle command event
-	$bot->callbackQuery(function ($message) use ($bot) 
-	{
-		$user_id = $message->getMessage()->getChat()->getId();
-		$callback_data = $message->getData();
-					
-		if(preg_match('/^command_/', $callback_data))
+	require_once "vendor/autoload.php";
+	
+	try {
+		$bot = new \TelegramBot\Api\Client('YOUR_BOT_API_TOKEN');
+		// or initialize with botan.io tracker api key
+		// $bot = new \TelegramBot\Api\Client('YOUR_BOT_API_TOKEN', 'YOUR_BOTAN_TRACKER_API_KEY');
+		
+		//Handle /ping command
+		$bot->command('ping', function ($message) use ($bot) {
+			$bot->sendMessage($message->getChat()->getId(), 'pong!');
+		});
+		
+		//Make test inline button
+		$bot->command('test_inline', function ($message) use ($bot) 
 		{
-			$command = preg_replace('/^command_/', '', $callback_data);
-			$message_json = $message->getMessage()->toJson();
-						
-			$bot->answerCallbackQuery($message->getId(), "Request command: {$command}. Loading...");
-						
-			if($messageSource = TelegramBot\Api\BotApi::jsonValidate($message_json, true))
+			$userid = $message->getChat()->getId();
+			
+			$buttons = Array();
+			$buttons[] = array("text" => 'runping', "callback_data" => "command_/ping");
+			
+			$keyboard = new \TelegramBot\Api\Types\Inline\InlineKeyboardMarkup(array($buttons));
+			
+			$message = "✅ TEST INLINE.";
+			$bot->sendMessage($userid, $message, null, false, null, null, $keyboard);
+		});
+		
+		//Handle command event
+		$bot->callbackQuery(function ($message) use ($bot) 
+		{
+			$user_id = $message->getMessage()->getChat()->getId();
+			$callback_data = $message->getData();
+			
+			if(preg_match('/^command_/', $callback_data))
 			{
+				$command = preg_replace('/^command_/', '', $callback_data);
+				$message_json = $message->getMessage()->toJson();
+				
+				$bot->answerCallbackQuery($message->getId(), "Request command: {$command}. Loading...");
+				
+				if($messageSource = TelegramBot\Api\BotApi::jsonValidate($message_json, true))
+				{
 					if(isset($messageSource['reply_markup']))
-						unset($messageSource['reply_markup']);
-						
+					unset($messageSource['reply_markup']);
+					
 					$messageSource['text'] = $command;
-							
+					
 					$event = $bot->get_event($command);
-							
+					
 					if($event !== false)
 					{
 						$data_json = json_encode(["update_id" => rand(11111111,99999999), "message" => $messageSource]);
-								
+						
 						if($data = TelegramBot\Api\BotApi::jsonValidate($data_json, true))
 						{
 							$update = TelegramBot\Api\Types\Update::fromResponse($data);
@@ -172,19 +172,19 @@ try {
 					}
 					else
 					$bot->sendMessage($userid, "🅰️Command '{$command}' not found!");
+				}
+				else
+				$bot->sendMessage($userid, "🅰️JSON error parse message source toJson build!");
 			}
-			else
-			$bot->sendMessage($userid, "🅰️JSON error parse message source toJson build!");
-		}
-        
-        /* OTHER CALLBACK CODE */
-	});
-    
-    $bot->run();
-
-} catch (\TelegramBot\Api\Exception $e) {
-    $e->getMessage();
-}
+			
+			/* OTHER CALLBACK CODE */
+		});
+		
+		$bot->run();
+		
+		} catch (\TelegramBot\Api\Exception $e) {
+		$e->getMessage();
+	}
 ```
 
 ### Botan SDK (not supported more)

--- a/src/Client.php
+++ b/src/Client.php
@@ -142,6 +142,27 @@ class Client
             $this->handle([Update::fromResponse($data)]);
         }
     }
+    /**
+     * Use this method to get already added event by command.
+     *
+     * @return \TelegramBot\Api\Events\Event or false on non found event
+     */
+    public function get_event($command)
+    {
+	    $events = $this->events;
+	
+	    foreach($events->events as $event)
+		{
+		   $checker = $event->getChecker();
+		   $closureReflection = new ReflectionFunction($checker);
+           $variables = $closureReflection->getStaticVariables();
+		    
+		   if(preg_match('/'.$variables['name'].'/', $command))
+			  return $event;
+		}
+	
+        return false;
+    }
 
     public function getRawBody()
     {


### PR DESCRIPTION
This is pull request add function get_event in Client.php which get \TelegramBot\Api\Events\Event of already defined command from events array by command name. It what need in issue #380 . For example we define function ping and test_inline, when we run test_inline we see inline button for test, so when we push on inline button we see answer of /ping command because /ping command is triggered.