### PR TITLE
added is_persistent parameter in ReplyKeyboardMarkup

### DIFF
--- a/src/Types/ReplyKeyboardMarkup.php
+++ b/src/Types/ReplyKeyboardMarkup.php
@@ -28,7 +28,8 @@ class ReplyKeyboardMarkup extends BaseType
         'keyboard' => true,
         'one_time_keyboard' => true,
         'resize_keyboard' => true,
-        'selective' => true
+        'selective' => true,
+        'is_persistent' => true
     ];
 
     /**
@@ -66,17 +67,27 @@ class ReplyKeyboardMarkup extends BaseType
     protected $selective;
 
     /**
+     * Optional. Requests clients to always show the keyboard when the regular keyboard is hidden.
+     * Defaults to false, in which case the custom keyboard can be hidden and opened with a keyboard icon.
+     *
+     * @var bool|null
+     */
+    protected $isPersistent;
+
+    /**
      * @param array $keyboard
      * @param bool|null $oneTimeKeyboard
      * @param bool|null $resizeKeyboard
      * @param bool|null $selective
+     * @param bool|null $isPersistent
      */
-    public function __construct($keyboard = [], $oneTimeKeyboard = null, $resizeKeyboard = null, $selective = null)
+    public function __construct($keyboard = [], $oneTimeKeyboard = null, $resizeKeyboard = null, $selective = null, $isPersistent = null)
     {
         $this->keyboard = $keyboard;
         $this->oneTimeKeyboard = $oneTimeKeyboard;
         $this->resizeKeyboard = $resizeKeyboard;
         $this->selective = $selective;
+        $this->isPersistent = $isPersistent;
     }
 
     /**
@@ -145,5 +156,22 @@ class ReplyKeyboardMarkup extends BaseType
     public function setSelective($selective)
     {
         $this->selective = $selective;
+    }
+
+    /**
+     * @return bool|null
+     */
+    public function getIsPersistent()
+    {
+        return $this->isPersistent;
+    }
+
+    /**
+     * @param bool $isPersistent
+     * @return void
+     */
+    public function setIsPersistent($isPersistent)
+    {
+        $this->isPersistent = $isPersistent;
     }
 }

--- a/tests/Types/ReplyKeyboardMarkupTest.php
+++ b/tests/Types/ReplyKeyboardMarkupTest.php
@@ -25,7 +25,8 @@ class ReplyKeyboardMarkupTest extends AbstractTypeTest
             'keyboard' => [['one', 'two']],
             'one_time_keyboard' => true,
             'resize_keyboard' => true,
-            'selective' => true
+            'selective' => true,
+            'is_persistent' => true,
         ];
     }
 
@@ -39,6 +40,7 @@ class ReplyKeyboardMarkupTest extends AbstractTypeTest
         $this->assertNull($item->isOneTimeKeyboard());
         $this->assertNull($item->isResizeKeyboard());
         $this->assertNull($item->isSelective());
+        $this->assertNull($item->getIsPersistent());
     }
 
     /**
@@ -51,6 +53,7 @@ class ReplyKeyboardMarkupTest extends AbstractTypeTest
         $this->assertEquals(true, $item->isOneTimeKeyboard());
         $this->assertEquals(true, $item->isResizeKeyboard());
         $this->assertEquals(true, $item->isSelective());
+        $this->assertEquals(true, $item->getIsPersistent());
     }
 
     public function testConstructor()
@@ -61,6 +64,7 @@ class ReplyKeyboardMarkupTest extends AbstractTypeTest
         $this->assertEquals(null, $item->isOneTimeKeyboard());
         $this->assertEquals(null, $item->isResizeKeyboard());
         $this->assertEquals(null, $item->isSelective());
+        $this->assertEquals(null, $item->getIsPersistent());
     }
 
     public function testConstructor2()
@@ -71,6 +75,7 @@ class ReplyKeyboardMarkupTest extends AbstractTypeTest
         $this->assertEquals(true, $item->isOneTimeKeyboard());
         $this->assertEquals(null, $item->isResizeKeyboard());
         $this->assertEquals(null, $item->isSelective());
+        $this->assertEquals(null, $item->getIsPersistent());
     }
 
     public function testConstructor3()
@@ -81,6 +86,7 @@ class ReplyKeyboardMarkupTest extends AbstractTypeTest
         $this->assertEquals(true, $item->isOneTimeKeyboard());
         $this->assertEquals(true, $item->isResizeKeyboard());
         $this->assertEquals(null, $item->isSelective());
+        $this->assertEquals(null, $item->getIsPersistent());
     }
 
     public function testConstructor4()
@@ -91,5 +97,17 @@ class ReplyKeyboardMarkupTest extends AbstractTypeTest
         $this->assertEquals(true, $item->isOneTimeKeyboard());
         $this->assertEquals(true, $item->isResizeKeyboard());
         $this->assertEquals(true, $item->isSelective());
+        $this->assertEquals(null, $item->getIsPersistent());
+    }
+
+    public function testConstructor5()
+    {
+        $item = new ReplyKeyboardMarkup([['one', 'two']], true, true, true, true);
+
+        $this->assertEquals([['one', 'two']], $item->getKeyboard());
+        $this->assertEquals(true, $item->isOneTimeKeyboard());
+        $this->assertEquals(true, $item->isResizeKeyboard());
+        $this->assertEquals(true, $item->isSelective());
+        $this->assertEquals(true, $item->getIsPersistent());
     }
 }


### PR DESCRIPTION
Please add the [is_persistent](https://core.telegram.org/bots/api#replykeyboardmarkup:~:text=of%20KeyboardButton%20objects-,is_persistent,-Boolean) parameter for the keyboard. For example, this pull request