### PR TITLE
Local Bot API Server support, Third-party http-client support and window.Telegram.WebApp.initData validation

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,6 +60,10 @@ jobs:
                 run: composer remove vimeo/psalm --dev --no-update
 
             -
+                name: Remove http client dependencies
+                run: composer remove psr/http-client psr/http-factory symfony/http-client guzzlehttp/guzzle --dev --no-update
+
+            -
                 name: Install dependencies with composer
                 run: composer update --prefer-dist --no-interaction --no-progress --optimize-autoloader --ansi
 

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -23,10 +23,12 @@ return (new PhpCsFixer\Config())
         'no_unused_imports' => true,
         'single_quote' => true,
         'no_extra_blank_lines' => true,
+        'array_indentation' => true,
         'cast_spaces' => true,
         'phpdoc_align' => [
             'align' => 'left',
         ],
         'binary_operator_spaces' => true,
+        'single_line_empty_body' => false,
     ])
 ;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All Notable changes to `PHP Telegram Bot Api` will be documented in this file
 - Add `\TelegramBot\Api\BotApi::revokeChatInviteLink` api method
 - Add `\TelegramBot\Api\BotApi::approveChatJoinRequest` api method
 - Add `\TelegramBot\Api\BotApi::declineChatJoinRequest` api method
+- Add support for third party http clients (`psr/http-client` and `symfony/http-client`)
+- Add support for local bot API server
+- Add method `\TelegramBot\Api\BotApi::validateWebAppData` to validate `window.Telegram.WebApp.initData`
 
 ## 2.5.0 - 2023-08-09
 

--- a/README.md
+++ b/README.md
@@ -82,9 +82,6 @@ require_once "vendor/autoload.php";
 
 try {
     $bot = new \TelegramBot\Api\Client('YOUR_BOT_API_TOKEN');
-    // or initialize with botan.io tracker api key
-    // $bot = new \TelegramBot\Api\Client('YOUR_BOT_API_TOKEN', 'YOUR_BOTAN_TRACKER_API_KEY');
-    
 
     //Handle /ping command
     $bot->command('ping', function ($message) use ($bot) {
@@ -107,44 +104,25 @@ try {
 }
 ```
 
-### Botan SDK (not supported more)
+#### Local Bot API Server
 
-[Botan](http://botan.io) is a telegram bot analytics system based on [Yandex.Appmetrica](http://appmetrica.yandex.com/).
-In this document you can find how to setup Yandex.Appmetrica account, as well as examples of Botan SDK usage.
-
-### Creating an account
- * Register at http://appmetrica.yandex.com/
- * After registration you will be prompted to create Application. Please use @YourBotName as a name.
- * Save an API key from settings page, you will use it as a token for Botan API calls.
- * Download lib for your language, and use it as described below. Don`t forget to insert your token!
-
-Since we are only getting started, you may discover that some existing reports in AppMetriсa aren't properly working for Telegram bots, like Geography, Gender, Age, Library, Devices, Traffic sources and Network sections. We will polish that later.
-
-## SDK usage
-
-#### Standalone
+For using custom [local bot API server](https://core.telegram.org/bots/api#using-a-local-bot-api-server)
 
 ```php
-$tracker = new \TelegramBot\Api\Botan('YOUR_BOTAN_TRACKER_API_KEY');
-
-$tracker->track($message, $eventName);
+use TelegramBot\Api\Client;
+$token = 'YOUR_BOT_API_TOKEN';
+$bot = new Client($token, null, null, 'http://localhost:8081');
 ```
 
-#### API Wrapper
+#### Third-party Http Client
+
 ```php
-$bot = new \TelegramBot\Api\BotApi('YOUR_BOT_API_TOKEN', 'YOUR_BOTAN_TRACKER_API_KEY');
-
-$bot->track($message, $eventName);
+use Symfony\Component\HttpClient\HttpClient;
+use TelegramBot\Api\BotApi;
+use TelegramBot\Api\Http\SymfonyHttpClient;
+$token = 'YOUR_BOT_API_TOKEN';
+$bot = new Client($token, null, new SymfonyHttpClient(HttpClient::create()););
 ```
-
- You can use method 'getUpdates()'and all incoming messages will be automatically tracked as `Message`-event.
-
-#### Client
-```php
-$bot = new \TelegramBot\Api\Client('YOUR_BOT_API_TOKEN', 'YOUR_BOTAN_TRACKER_API_KEY');
-```
-
-_All registered commands are automatically tracked as command name_
 
 ## Change log
 

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,18 @@
     },
     "require-dev": {
         "symfony/phpunit-bridge" : "*",
-        "friendsofphp/php-cs-fixer": "^3.16",
-        "vimeo/psalm": "^5.9"
+        "friendsofphp/php-cs-fixer": "~3.28.0",
+        "vimeo/psalm": "^5.9",
+        "psr/http-client": "^1.0",
+        "psr/http-factory": "^1.0",
+        "symfony/http-client": "^4.3 | ^5.0 | ^6.0",
+        "guzzlehttp/guzzle": "^7.0"
+    },
+    "suggest": {
+        "psr/http-client": "To use psr/http-client",
+        "psr/http-factory": "To use psr/http-client",
+        "guzzlehttp/guzzle": "To use psr/http-client",
+        "symfony/http-client": "To use symfony/http-client"
     },
     "autoload": {
         "psr-4": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -19,10 +19,9 @@
         <MissingConstructor errorLevel="suppress" />
         <PropertyNotSetInConstructor errorLevel="suppress" />
         <RedundantCastGivenDocblockType errorLevel="suppress" />
-        <DeprecatedClass>
-            <errorLevel type="suppress">
-                <referencedClass name="TelegramBot\Api\Botan" />
-            </errorLevel>
-        </DeprecatedClass>
+        <DeprecatedConstant errorLevel="suppress" />
+        <DeprecatedMethod errorLevel="suppress" />
+        <DeprecatedClass errorLevel="suppress" />
+        <DeprecatedProperty errorLevel="suppress" />
     </issueHandlers>
 </psalm>

--- a/src/Botan.php
+++ b/src/Botan.php
@@ -34,14 +34,10 @@ class Botan
      *
      * @param string $token
      *
-     * @throws \Exception
+     * @throws InvalidArgumentException
      */
     public function __construct($token)
     {
-        if (!function_exists('curl_version')) {
-            throw new Exception('CURL not installed');
-        }
-
         if (empty($token)) {
             throw new InvalidArgumentException('Token should not be empty');
         }

--- a/src/Client.php
+++ b/src/Client.php
@@ -5,6 +5,7 @@ namespace TelegramBot\Api;
 use Closure;
 use ReflectionFunction;
 use TelegramBot\Api\Events\EventCollection;
+use TelegramBot\Api\Http\HttpClientInterface;
 use TelegramBot\Api\Types\Update;
 use TelegramBot\Api\Types\Message;
 use TelegramBot\Api\Types\Inline\InlineKeyboardMarkup;
@@ -40,13 +41,15 @@ class Client
      *
      * @param string $token Telegram Bot API token
      * @param string|null $trackerToken Yandex AppMetrica application api_key
+     * @param HttpClientInterface|null $httpClient
+     * @param string|null $endpoint
      */
-    public function __construct($token, $trackerToken = null)
+    public function __construct($token, $trackerToken = null, HttpClientInterface $httpClient = null, $endpoint = null)
     {
         if ($trackerToken) {
             @trigger_error(sprintf('Passing $trackerToken to %s is deprecated', self::class), \E_USER_DEPRECATED);
         }
-        $this->api = new BotApi($token);
+        $this->api = new BotApi($token, $trackerToken, $httpClient, $endpoint);
         $this->events = new EventCollection($trackerToken);
     }
 

--- a/src/Events/EventCollection.php
+++ b/src/Events/EventCollection.php
@@ -48,8 +48,7 @@ class EventCollection
     public function add(Closure $event, $checker = null)
     {
         $this->events[] = !is_null($checker) ? new Event($event, $checker)
-            : new Event($event, function () {
-            });
+            : new Event($event, function () {});
 
         return $this;
     }

--- a/src/Http/AbstractHttpClient.php
+++ b/src/Http/AbstractHttpClient.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace TelegramBot\Api\Http;
+
+use TelegramBot\Api\Exception;
+
+abstract class AbstractHttpClient implements HttpClientInterface
+{
+    public function request($url, array $data = null)
+    {
+        $response = $this->doRequest($url, $data);
+
+        if (!isset($response['ok']) || !$response['ok']) {
+            throw new Exception($response['description'], $response['error_code']);
+        }
+
+        return $response['result'];
+    }
+
+    public function download($url)
+    {
+        return $this->doDownload($url);
+    }
+
+    /**
+     * @param string $url
+     * @param array|null $data
+     * @return array
+     */
+    abstract protected function doRequest($url, array $data = null);
+
+    /**
+     * @param string $url
+     * @return string
+     */
+    abstract protected function doDownload($url);
+}

--- a/src/Http/CurlHttpClient.php
+++ b/src/Http/CurlHttpClient.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace TelegramBot\Api\Http;
+
+use TelegramBot\Api\HttpException;
+use TelegramBot\Api\InvalidJsonException;
+
+class CurlHttpClient extends AbstractHttpClient
+{
+    /**
+     * HTTP codes
+     *
+     * @var array
+     */
+    private static $codes = [
+        // Informational 1xx
+        100 => 'Continue',
+        101 => 'Switching Protocols',
+        102 => 'Processing',            // RFC2518
+        // Success 2xx
+        200 => 'OK',
+        201 => 'Created',
+        202 => 'Accepted',
+        203 => 'Non-Authoritative Information',
+        204 => 'No Content',
+        205 => 'Reset Content',
+        206 => 'Partial Content',
+        207 => 'Multi-Status',          // RFC4918
+        208 => 'Already Reported',      // RFC5842
+        226 => 'IM Used',               // RFC3229
+        // Redirection 3xx
+        300 => 'Multiple Choices',
+        301 => 'Moved Permanently',
+        302 => 'Found', // 1.1
+        303 => 'See Other',
+        304 => 'Not Modified',
+        305 => 'Use Proxy',
+        // 306 is deprecated but reserved
+        307 => 'Temporary Redirect',
+        308 => 'Permanent Redirect',    // RFC7238
+        // Client Error 4xx
+        400 => 'Bad Request',
+        401 => 'Unauthorized',
+        402 => 'Payment Required',
+        403 => 'Forbidden',
+        404 => 'Not Found',
+        405 => 'Method Not Allowed',
+        406 => 'Not Acceptable',
+        407 => 'Proxy Authentication Required',
+        408 => 'Request Timeout',
+        409 => 'Conflict',
+        410 => 'Gone',
+        411 => 'Length Required',
+        412 => 'Precondition Failed',
+        413 => 'Payload Too Large',
+        414 => 'URI Too Long',
+        415 => 'Unsupported Media Type',
+        416 => 'Range Not Satisfiable',
+        417 => 'Expectation Failed',
+        422 => 'Unprocessable Entity',                                        // RFC4918
+        423 => 'Locked',                                                      // RFC4918
+        424 => 'Failed Dependency',                                           // RFC4918
+        425 => 'Reserved for WebDAV advanced collections expired proposal',   // RFC2817
+        426 => 'Upgrade Required',                                            // RFC2817
+        428 => 'Precondition Required',                                       // RFC6585
+        429 => 'Too Many Requests',                                           // RFC6585
+        431 => 'Request Header Fields Too Large',                             // RFC6585
+        // Server Error 5xx
+        500 => 'Internal Server Error',
+        501 => 'Not Implemented',
+        502 => 'Bad Gateway',
+        503 => 'Service Unavailable',
+        504 => 'Gateway Timeout',
+        505 => 'HTTP Version Not Supported',
+        506 => 'Variant Also Negotiates (Experimental)',                      // RFC2295
+        507 => 'Insufficient Storage',                                        // RFC4918
+        508 => 'Loop Detected',                                               // RFC5842
+        510 => 'Not Extended',                                                // RFC2774
+        511 => 'Network Authentication Required',                             // RFC6585
+    ];
+
+    /**
+     * Default http status code
+     */
+    const DEFAULT_STATUS_CODE = 200;
+
+    /**
+     * Not Modified http status code
+     */
+    const NOT_MODIFIED_STATUS_CODE = 304;
+
+    /**
+     * CURL object
+     *
+     * @var resource
+     */
+    private $curl;
+
+    /**
+     * @var array
+     */
+    private $options;
+
+    public function __construct(array $options = [])
+    {
+        $this->curl = curl_init();
+        $this->options = $options;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function doRequest($url, array $data = null)
+    {
+        $options = $this->options + [
+            CURLOPT_URL => $url,
+            CURLOPT_RETURNTRANSFER => true,
+        ];
+
+        if ($data) {
+            $options[CURLOPT_POST] = true;
+            $options[CURLOPT_POSTFIELDS] = $data;
+        }
+
+        return self::jsonValidate($this->execute($options));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function doDownload($url)
+    {
+        $options = [
+            CURLOPT_HEADER => false,
+            CURLOPT_HTTPGET => true,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_URL => $url,
+        ];
+
+        return $this->execute($options);
+    }
+
+    /**
+     * @param array $options
+     * @return string
+     * @throws HttpException
+     */
+    private function execute(array $options)
+    {
+        curl_setopt_array($this->curl, $options);
+
+        /** @var string|false $result */
+        $result = curl_exec($this->curl);
+        if ($result === false) {
+            throw new HttpException(curl_error($this->curl), curl_errno($this->curl));
+        }
+
+        self::curlValidate($this->curl, $result);
+
+        return $result;
+    }
+
+    /**
+     * @param string $jsonString
+     * @return array
+     * @throws InvalidJsonException
+     */
+    private static function jsonValidate($jsonString)
+    {
+        /** @var array $json */
+        $json = json_decode($jsonString, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new InvalidJsonException(json_last_error_msg(), json_last_error());
+        }
+
+        return $json;
+    }
+
+    /**
+     * @param resource $curl
+     * @param string|null $response
+     * @return void
+     * @throws HttpException
+     */
+    private static function curlValidate($curl, $response = null)
+    {
+        $json = json_decode((string) $response, true) ?: [];
+
+        if (($httpCode = curl_getinfo($curl, CURLINFO_HTTP_CODE))
+            && !in_array($httpCode, [self::DEFAULT_STATUS_CODE, self::NOT_MODIFIED_STATUS_CODE])
+        ) {
+            $errorDescription = array_key_exists('description', $json) ? $json['description'] : self::$codes[$httpCode];
+            $errorParameters = array_key_exists('parameters', $json) ? $json['parameters'] : [];
+
+            throw new HttpException($errorDescription, $httpCode, null, $errorParameters);
+        }
+    }
+
+    /**
+     * @param string $option
+     * @param string|int|bool $value
+     * @return void
+     */
+    public function setOption($option, $value)
+    {
+        $this->options[$option] = $value;
+    }
+
+    /**
+     * @param string $option
+     * @return void
+     */
+    public function unsetOption($option)
+    {
+        unset($this->options[$option]);
+    }
+
+    /**
+     * @return void
+     */
+    public function resetOptions()
+    {
+        $this->options = [];
+    }
+}

--- a/src/Http/HttpClientInterface.php
+++ b/src/Http/HttpClientInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace TelegramBot\Api\Http;
+
+use TelegramBot\Api\Exception;
+use TelegramBot\Api\HttpException;
+
+interface HttpClientInterface
+{
+    /**
+     * Request url
+     *
+     * @param string $url
+     * @param array|null $data
+     * @return mixed
+     * @throws Exception
+     */
+    public function request($url, array $data = null);
+
+    /**
+     * Get file contents
+     *
+     * @param string $url
+     *
+     * @return string
+     *
+     * @throws HttpException
+     * @throws Exception
+     */
+    public function download($url);
+}

--- a/src/Http/PsrHttpClient.php
+++ b/src/Http/PsrHttpClient.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace TelegramBot\Api\Http;
+
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use TelegramBot\Api\HttpException;
+use TelegramBot\Api\InvalidJsonException;
+
+class PsrHttpClient extends AbstractHttpClient
+{
+    /**
+     * @var ClientInterface
+     */
+    private $http;
+
+    /**
+     * @var RequestFactoryInterface
+     */
+    private $requestFactory;
+
+    public function __construct(ClientInterface $http, RequestFactoryInterface $requestFactory)
+    {
+        $this->http = $http;
+        $this->requestFactory = $requestFactory;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function doRequest($url, array $data = null)
+    {
+        if ($data) {
+            $method = 'POST';
+        } else {
+            $method = 'GET';
+        }
+
+        $request = $this->requestFactory->createRequest($method, $url);
+        try {
+            $response = $this->http->sendRequest($request);
+        } catch (ClientExceptionInterface $exception) {
+            throw new HttpException($exception->getMessage(), $exception->getCode(), $exception);
+        }
+
+        $content = $response->getBody()->getContents();
+
+        return self::jsonValidate($content);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function doDownload($url)
+    {
+        $request = $this->requestFactory->createRequest('GET', $url);
+
+        try {
+            return $this->http->sendRequest($request)->getBody()->getContents();
+        } catch (ClientExceptionInterface $exception) {
+            throw new HttpException($exception->getMessage(), $exception->getCode(), $exception);
+        }
+    }
+
+    /**
+     * @param string $jsonString
+     * @return array
+     * @throws InvalidJsonException
+     */
+    private static function jsonValidate($jsonString)
+    {
+        /** @var array $json */
+        $json = json_decode($jsonString, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new InvalidJsonException(json_last_error_msg(), json_last_error());
+        }
+
+        return $json;
+    }
+}

--- a/src/Http/SymfonyHttpClient.php
+++ b/src/Http/SymfonyHttpClient.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace TelegramBot\Api\Http;
+
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface as SymfonyHttpClientInterface;
+use TelegramBot\Api\HttpException;
+
+class SymfonyHttpClient extends AbstractHttpClient
+{
+    /**
+     * @var SymfonyHttpClientInterface
+     */
+    private $http;
+
+    public function __construct(SymfonyHttpClientInterface $http)
+    {
+        $this->http = $http;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function doRequest($url, array $data = null)
+    {
+        $options = [];
+        if ($data) {
+            $method = 'POST';
+            $options['body'] = $data;
+        } else {
+            $method = 'GET';
+        }
+
+        $response = $this->http->request($method, $url, $options);
+
+        try {
+            return $response->toArray();
+        } catch (ExceptionInterface $exception) {
+            throw new HttpException($exception->getMessage(), $exception->getCode(), $exception);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function doDownload($url)
+    {
+        try {
+            return $this->http->request('GET', $url)->getContent();
+        } catch (ExceptionInterface $exception) {
+            throw new HttpException($exception->getMessage(), $exception->getCode(), $exception);
+        }
+    }
+}

--- a/src/HttpException.php
+++ b/src/HttpException.php
@@ -20,10 +20,10 @@ class HttpException extends Exception
      *
      * @param string $message [optional] The Exception message to throw.
      * @param int $code [optional] The Exception code.
-     * @param Exception $previous [optional] The previous throwable used for the exception chaining.
+     * @param \Throwable|\Exception $previous [optional] The previous throwable used for the exception chaining.
      * @param array $parameters [optional] Array of parameters returned from API.
      */
-    public function __construct($message = '', $code = 0, Exception $previous = null, $parameters = [])
+    public function __construct($message = '', $code = 0, $previous = null, $parameters = [])
     {
         $this->parameters = $parameters;
 

--- a/tests/Types/ArrayOfMessageEntityTest.php
+++ b/tests/Types/ArrayOfMessageEntityTest.php
@@ -11,11 +11,11 @@ class ArrayOfMessageEntityTest extends TestCase
     public function testFromResponse()
     {
         $items = ArrayOfMessageEntity::fromResponse([
-           [
-               'type' => 'mention',
-               'offset' => 0,
-               'length' => 10,
-           ],
+            [
+                'type' => 'mention',
+                'offset' => 0,
+                'length' => 10,
+            ],
         ]);
 
         $expected = [


### PR DESCRIPTION
Local Bot API Server support (Fixes #301)
Third-party http-client support (`psr/http-client` and `symfony/http-client`)
`window.Telegram.WebApp.initData` validation