### PR TITLE
Clean PHP 8.4 related warnings

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,10 +15,12 @@ jobs:
                 php:
                     - "8.1"
                     - "8.2"
+                    - "8.3"
+                    - "8.4"
         steps:
             -
                 name: Checkout
-                uses: actions/checkout@v2
+                uses: actions/checkout@v4
 
             -
                 name: Install PHP
@@ -33,7 +35,7 @@ jobs:
 
             -
                 name: Cache dependencies installed with composer
-                uses: actions/cache@v2
+                uses: actions/cache@v4
                 with:
                     path: ${{ env.COMPOSER_CACHE_DIR }}
                     key: php${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}

--- a/src/BotApi.php
+++ b/src/BotApi.php
@@ -177,7 +177,7 @@ class BotApi
      * @param HttpClientInterface|null $httpClient
      * @param string|null $endpoint
      */
-    public function __construct($token, HttpClientInterface $httpClient = null, $endpoint = null)
+    public function __construct($token, ?HttpClientInterface $httpClient = null, $endpoint = null)
     {
         $this->token = $token;
         $this->endpoint = ($endpoint ?: self::URL_PREFIX) . $token;

--- a/src/Client.php
+++ b/src/Client.php
@@ -43,7 +43,7 @@ class Client
      * @param HttpClientInterface|null $httpClient
      * @param string|null $endpoint
      */
-    public function __construct($token, HttpClientInterface $httpClient = null, $endpoint = null)
+    public function __construct($token, ?HttpClientInterface $httpClient = null, $endpoint = null)
     {
         $this->api = new BotApi($token, $httpClient, $endpoint);
         $this->events = new EventCollection();
@@ -135,7 +135,7 @@ class Client
      *
      * @return \TelegramBot\Api\Client
      */
-    public function on(Closure $event, Closure $checker = null)
+    public function on(Closure $event, ?Closure $checker = null)
     {
         $this->events->add($event, $checker);
 

--- a/src/Events/Event.php
+++ b/src/Events/Event.php
@@ -22,7 +22,7 @@ class Event
      * @param \Closure $action
      * @param \Closure|null $checker
      */
-    public function __construct(\Closure $action, \Closure $checker = null)
+    public function __construct(\Closure $action, ?\Closure $checker = null)
     {
         $this->action = $action;
         $this->checker = $checker;

--- a/src/Http/AbstractHttpClient.php
+++ b/src/Http/AbstractHttpClient.php
@@ -6,7 +6,7 @@ use TelegramBot\Api\Exception;
 
 abstract class AbstractHttpClient implements HttpClientInterface
 {
-    public function request($url, array $data = null)
+    public function request($url, ?array $data = null)
     {
         $response = $this->doRequest($url, $data);
 
@@ -27,7 +27,7 @@ abstract class AbstractHttpClient implements HttpClientInterface
      * @param array|null $data
      * @return array
      */
-    abstract protected function doRequest($url, array $data = null);
+    abstract protected function doRequest($url, ?array $data = null);
 
     /**
      * @param string $url

--- a/src/Http/CurlHttpClient.php
+++ b/src/Http/CurlHttpClient.php
@@ -110,7 +110,7 @@ class CurlHttpClient extends AbstractHttpClient
     /**
      * @inheritDoc
      */
-    protected function doRequest($url, array $data = null)
+    protected function doRequest($url, ?array $data = null)
     {
         $options = $this->options + [
             CURLOPT_URL => $url,

--- a/src/Http/HttpClientInterface.php
+++ b/src/Http/HttpClientInterface.php
@@ -15,7 +15,7 @@ interface HttpClientInterface
      * @return mixed
      * @throws Exception
      */
-    public function request($url, array $data = null);
+    public function request($url, ?array $data = null);
 
     /**
      * Get file contents

--- a/src/Http/PsrHttpClient.php
+++ b/src/Http/PsrHttpClient.php
@@ -40,7 +40,7 @@ class PsrHttpClient extends AbstractHttpClient
     /**
      * @inheritDoc
      */
-    protected function doRequest($url, array $data = null)
+    protected function doRequest($url, ?array $data = null)
     {
         if ($data) {
             $method = 'POST';

--- a/src/Http/SymfonyHttpClient.php
+++ b/src/Http/SymfonyHttpClient.php
@@ -24,7 +24,7 @@ class SymfonyHttpClient extends AbstractHttpClient
     /**
      * @inheritDoc
      */
-    protected function doRequest($url, array $data = null)
+    protected function doRequest($url, ?array $data = null)
     {
         $options = [];
         if ($data) {


### PR DESCRIPTION
This pull request is to fix warnings in PHP 8.4:
 - Implicitly marking parameter as nullable is deprecated, the explicit nullable type must be used instead

See https://www.php.net/manual/en/migration84.deprecated.php
