### PR TITLE
Add various API types

### DIFF
--- a/src/Types/AcceptedGiftTypes.php
+++ b/src/Types/AcceptedGiftTypes.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+
+class AcceptedGiftTypes extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['unlimited_gifts', 'limited_gifts', 'unique_gifts', 'premium_subscription'];
+
+    protected static $map = [
+        'unlimited_gifts' => true,
+        'limited_gifts' => true,
+        'unique_gifts' => true,
+        'premium_subscription' => true,
+    ];
+
+    protected $unlimitedGifts;
+    protected $limitedGifts;
+    protected $uniqueGifts;
+    protected $premiumSubscription;
+
+    public function getUnlimitedGifts()
+    {
+        return $this->unlimitedGifts;
+    }
+
+    public function setUnlimitedGifts($unlimitedGifts)
+    {
+        $this->unlimitedGifts = $unlimitedGifts;
+    }
+
+    public function getLimitedGifts()
+    {
+        return $this->limitedGifts;
+    }
+
+    public function setLimitedGifts($limitedGifts)
+    {
+        $this->limitedGifts = $limitedGifts;
+    }
+
+    public function getUniqueGifts()
+    {
+        return $this->uniqueGifts;
+    }
+
+    public function setUniqueGifts($uniqueGifts)
+    {
+        $this->uniqueGifts = $uniqueGifts;
+    }
+
+    public function getPremiumSubscription()
+    {
+        return $this->premiumSubscription;
+    }
+
+    public function setPremiumSubscription($premiumSubscription)
+    {
+        $this->premiumSubscription = $premiumSubscription;
+    }
+}

--- a/src/Types/ArrayOfGift.php
+++ b/src/Types/ArrayOfGift.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace TelegramBot\Api\Types;
+
+use TelegramBot\Api\InvalidArgumentException;
+
+abstract class ArrayOfGift
+{
+    /**
+     * @param array $data
+     * @return Gift[]
+     * @throws InvalidArgumentException
+     */
+    public static function fromResponse($data)
+    {
+        $array = [];
+        foreach ($data as $datum) {
+            $array[] = Gift::fromResponse($datum);
+        }
+
+        return $array;
+    }
+}

--- a/src/Types/ArrayOfOwnedGift.php
+++ b/src/Types/ArrayOfOwnedGift.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace TelegramBot\Api\Types;
+
+use TelegramBot\Api\InvalidArgumentException;
+
+abstract class ArrayOfOwnedGift
+{
+    /**
+     * @param array $data
+     * @return OwnedGift[]
+     * @throws InvalidArgumentException
+     */
+    public static function fromResponse($data)
+    {
+        $array = [];
+        foreach ($data as $datum) {
+            $array[] = OwnedGift::fromResponse($datum);
+        }
+
+        return $array;
+    }
+}

--- a/src/Types/BotCommandScope.php
+++ b/src/Types/BotCommandScope.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\InvalidArgumentException;
+use TelegramBot\\Api\\TypeInterface;
+
+abstract class BotCommandScope extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['type'];
+    protected static $map = ['type' => true];
+
+    /**
+     * @psalm-suppress LessSpecificReturnType,MoreSpecificReturnType
+     */
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        switch ($data['type']) {
+            case 'default':
+                return BotCommandScopeDefault::fromResponse($data);
+            case 'all_private_chats':
+                return BotCommandScopeAllPrivateChats::fromResponse($data);
+            case 'all_group_chats':
+                return BotCommandScopeAllGroupChats::fromResponse($data);
+            case 'all_chat_administrators':
+                return BotCommandScopeAllChatAdministrators::fromResponse($data);
+            case 'chat':
+                return BotCommandScopeChat::fromResponse($data);
+            case 'chat_administrators':
+                return BotCommandScopeChatAdministrators::fromResponse($data);
+            case 'chat_member':
+                return BotCommandScopeChatMember::fromResponse($data);
+            default:
+                throw new InvalidArgumentException('Unknown bot command scope type: ' . $data['type']);
+        }
+    }
+
+    protected $type;
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+}

--- a/src/Types/BotCommandScopeAllChatAdministrators.php
+++ b/src/Types/BotCommandScopeAllChatAdministrators.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class BotCommandScopeAllChatAdministrators
+ * Represents the scope covering all group and supergroup chat administrators.
+ */
+class BotCommandScopeAllChatAdministrators extends BotCommandScope
+{
+    protected static $requiredParams = ['type'];
+
+    protected static $map = [
+        'type' => true
+    ];
+
+    protected $type = 'all_chat_administrators';
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+}

--- a/src/Types/BotCommandScopeAllGroupChats.php
+++ b/src/Types/BotCommandScopeAllGroupChats.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class BotCommandScopeAllGroupChats
+ * Represents the scope covering all group and supergroup chats.
+ */
+class BotCommandScopeAllGroupChats extends BotCommandScope
+{
+    protected static $requiredParams = ['type'];
+
+    protected static $map = [
+        'type' => true
+    ];
+
+    protected $type = 'all_group_chats';
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+}

--- a/src/Types/BotCommandScopeAllPrivateChats.php
+++ b/src/Types/BotCommandScopeAllPrivateChats.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class BotCommandScopeAllPrivateChats
+ * Represents the scope covering all private chats.
+ */
+class BotCommandScopeAllPrivateChats extends BotCommandScope
+{
+    protected static $requiredParams = ['type'];
+
+    protected static $map = [
+        'type' => true
+    ];
+
+    protected $type = 'all_private_chats';
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+}

--- a/src/Types/BotCommandScopeChat.php
+++ b/src/Types/BotCommandScopeChat.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class BotCommandScopeChat
+ * Represents the scope of bot commands, covering a specific chat.
+ */
+class BotCommandScopeChat extends BotCommandScope
+{
+    protected static $requiredParams = ['type', 'chat_id'];
+
+    protected static $map = [
+        'type' => true,
+        'chat_id' => true
+    ];
+
+    protected $type = 'chat';
+    protected $chatId;
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+
+    public function getChatId()
+    {
+        return $this->chatId;
+    }
+
+    public function setChatId($chatId)
+    {
+        $this->chatId = $chatId;
+    }
+}

--- a/src/Types/BotCommandScopeChatAdministrators.php
+++ b/src/Types/BotCommandScopeChatAdministrators.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class BotCommandScopeChatAdministrators
+ * Represents the scope covering all administrators of a specific chat.
+ */
+class BotCommandScopeChatAdministrators extends BotCommandScope
+{
+    protected static $requiredParams = ['type', 'chat_id'];
+
+    protected static $map = [
+        'type' => true,
+        'chat_id' => true
+    ];
+
+    protected $type = 'chat_administrators';
+    protected $chatId;
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+
+    public function getChatId()
+    {
+        return $this->chatId;
+    }
+
+    public function setChatId($chatId)
+    {
+        $this->chatId = $chatId;
+    }
+}

--- a/src/Types/BotCommandScopeChatMember.php
+++ b/src/Types/BotCommandScopeChatMember.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class BotCommandScopeChatMember
+ * Represents the scope covering a specific member of a chat.
+ */
+class BotCommandScopeChatMember extends BotCommandScope
+{
+    protected static $requiredParams = ['type', 'chat_id', 'user_id'];
+
+    protected static $map = [
+        'type' => true,
+        'chat_id' => true,
+        'user_id' => true
+    ];
+
+    protected $type = 'chat_member';
+    protected $chatId;
+    protected $userId;
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+
+    public function getChatId()
+    {
+        return $this->chatId;
+    }
+
+    public function setChatId($chatId)
+    {
+        $this->chatId = $chatId;
+    }
+
+    public function getUserId()
+    {
+        return $this->userId;
+    }
+
+    public function setUserId($userId)
+    {
+        $this->userId = $userId;
+    }
+}

--- a/src/Types/BotCommandScopeDefault.php
+++ b/src/Types/BotCommandScopeDefault.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class BotCommandScopeDefault
+ * Represents the default scope of bot commands.
+ */
+class BotCommandScopeDefault extends BotCommandScope
+{
+    protected static $requiredParams = ['type'];
+
+    protected static $map = [
+        'type' => true
+    ];
+
+    protected $type = 'default';
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+}

--- a/src/Types/BotName.php
+++ b/src/Types/BotName.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+
+/**
+ * Class BotName
+ * Represents the bot's name.
+ */
+class BotName extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['name'];
+
+    protected static $map = [
+        'name' => true
+    ];
+
+    protected $name;
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/src/Types/BusinessBotRights.php
+++ b/src/Types/BusinessBotRights.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+
+/**
+ * Class BusinessBotRights
+ * Represents the rights of a business bot.
+ */
+class BusinessBotRights extends BaseType implements TypeInterface
+{
+    protected static $map = [
+        'can_reply' => true,
+        'can_read_messages' => true,
+        'can_delete_sent_messages' => true,
+        'can_delete_all_messages' => true,
+        'can_edit_name' => true,
+        'can_edit_bio' => true,
+        'can_edit_profile_photo' => true,
+        'can_edit_username' => true,
+        'can_change_gift_settings' => true,
+        'can_view_gifts_and_stars' => true,
+        'can_convert_gifts_to_stars' => true,
+        'can_transfer_and_upgrade_gifts' => true,
+        'can_transfer_stars' => true,
+        'can_manage_stories' => true
+    ];
+
+    protected $canReply;
+    protected $canReadMessages;
+    protected $canDeleteSentMessages;
+    protected $canDeleteAllMessages;
+    protected $canEditName;
+    protected $canEditBio;
+    protected $canEditProfilePhoto;
+    protected $canEditUsername;
+    protected $canChangeGiftSettings;
+    protected $canViewGiftsAndStars;
+    protected $canConvertGiftsToStars;
+    protected $canTransferAndUpgradeGifts;
+    protected $canTransferStars;
+    protected $canManageStories;
+
+    public function getCanReply()
+    {
+        return $this->canReply;
+    }
+
+    public function setCanReply($value)
+    {
+        $this->canReply = $value;
+    }
+}

--- a/src/Types/CopyTextButton.php
+++ b/src/Types/CopyTextButton.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+
+/**
+ * Class CopyTextButton
+ * Represents an inline keyboard button that copies specified text to the clipboard.
+ */
+class CopyTextButton extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['text'];
+
+    protected static $map = [
+        'text' => true
+    ];
+
+    protected $text;
+
+    public function getText()
+    {
+        return $this->text;
+    }
+
+    public function setText($text)
+    {
+        $this->text = $text;
+    }
+}

--- a/src/Types/Gift.php
+++ b/src/Types/Gift.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+
+/**
+ * Class Gift
+ * This object represents a gift that can be sent by the bot.
+ */
+class Gift extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['id', 'sticker', 'star_count'];
+
+    protected static $map = [
+        'id' => true,
+        'sticker' => Sticker::class,
+        'star_count' => true,
+        'upgrade_star_count' => true,
+        'total_count' => true,
+        'remaining_count' => true,
+    ];
+
+    protected $id;
+    protected $sticker;
+    protected $starCount;
+    protected $upgradeStarCount;
+    protected $totalCount;
+    protected $remainingCount;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    public function getSticker()
+    {
+        return $this->sticker;
+    }
+
+    public function setSticker($sticker)
+    {
+        $this->sticker = $sticker;
+    }
+
+    public function getStarCount()
+    {
+        return $this->starCount;
+    }
+
+    public function setStarCount($starCount)
+    {
+        $this->starCount = $starCount;
+    }
+
+    public function getUpgradeStarCount()
+    {
+        return $this->upgradeStarCount;
+    }
+
+    public function setUpgradeStarCount($upgradeStarCount)
+    {
+        $this->upgradeStarCount = $upgradeStarCount;
+    }
+
+    public function getTotalCount()
+    {
+        return $this->totalCount;
+    }
+
+    public function setTotalCount($totalCount)
+    {
+        $this->totalCount = $totalCount;
+    }
+
+    public function getRemainingCount()
+    {
+        return $this->remainingCount;
+    }
+
+    public function setRemainingCount($remainingCount)
+    {
+        $this->remainingCount = $remainingCount;
+    }
+}

--- a/src/Types/GiftInfo.php
+++ b/src/Types/GiftInfo.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+
+class GiftInfo extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['gift'];
+
+    protected static $map = [
+        'gift' => Gift::class,
+        'owned_gift_id' => true,
+        'convert_star_count' => true,
+        'prepaid_upgrade_star_count' => true,
+        'can_be_upgraded' => true,
+        'text' => true,
+        'entities' => ArrayOfMessageEntity::class,
+        'is_private' => true,
+    ];
+
+    protected $gift;
+    protected $ownedGiftId;
+    protected $convertStarCount;
+    protected $prepaidUpgradeStarCount;
+    protected $canBeUpgraded;
+    protected $text;
+    protected $entities;
+    protected $isPrivate;
+
+    public function getGift()
+    {
+        return $this->gift;
+    }
+
+    public function setGift($gift)
+    {
+        $this->gift = $gift;
+    }
+
+    public function getOwnedGiftId()
+    {
+        return $this->ownedGiftId;
+    }
+
+    public function setOwnedGiftId($ownedGiftId)
+    {
+        $this->ownedGiftId = $ownedGiftId;
+    }
+
+    public function getConvertStarCount()
+    {
+        return $this->convertStarCount;
+    }
+
+    public function setConvertStarCount($convertStarCount)
+    {
+        $this->convertStarCount = $convertStarCount;
+    }
+
+    public function getPrepaidUpgradeStarCount()
+    {
+        return $this->prepaidUpgradeStarCount;
+    }
+
+    public function setPrepaidUpgradeStarCount($prepaidUpgradeStarCount)
+    {
+        $this->prepaidUpgradeStarCount = $prepaidUpgradeStarCount;
+    }
+
+    public function getCanBeUpgraded()
+    {
+        return $this->canBeUpgraded;
+    }
+
+    public function setCanBeUpgraded($canBeUpgraded)
+    {
+        $this->canBeUpgraded = $canBeUpgraded;
+    }
+
+    public function getText()
+    {
+        return $this->text;
+    }
+
+    public function setText($text)
+    {
+        $this->text = $text;
+    }
+
+    public function getEntities()
+    {
+        return $this->entities;
+    }
+
+    public function setEntities($entities)
+    {
+        $this->entities = $entities;
+    }
+
+    public function getIsPrivate()
+    {
+        return $this->isPrivate;
+    }
+
+    public function setIsPrivate($isPrivate)
+    {
+        $this->isPrivate = $isPrivate;
+    }
+}

--- a/src/Types/Gifts.php
+++ b/src/Types/Gifts.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+
+class Gifts extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['gifts'];
+
+    protected static $map = [
+        'gifts' => ArrayOfGift::class,
+    ];
+
+    protected $gifts;
+
+    public function getGifts()
+    {
+        return $this->gifts;
+    }
+
+    public function setGifts($gifts)
+    {
+        $this->gifts = $gifts;
+    }
+}

--- a/src/Types/InputFile.php
+++ b/src/Types/InputFile.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+
+/**
+ * Class InputFile
+ * Represents the contents of a file to be uploaded.
+ */
+class InputFile extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = [];
+
+    protected static $map = [
+        'file' => true
+    ];
+
+    protected $file;
+
+    public function __construct($file = null)
+    {
+        if ($file !== null) {
+            $this->file = $file;
+        }
+    }
+
+    public function getFile()
+    {
+        return $this->file;
+    }
+
+    public function setFile($file)
+    {
+        $this->file = $file;
+    }
+}

--- a/src/Types/InputPaidMedia.php
+++ b/src/Types/InputPaidMedia.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\InvalidArgumentException;
+use TelegramBot\\Api\\TypeInterface;
+
+abstract class InputPaidMedia extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['type', 'media'];
+
+    protected static $map = [
+        'type' => true,
+        'media' => true
+    ];
+
+    /**
+     * @psalm-suppress LessSpecificReturnType,MoreSpecificReturnType
+     */
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        switch ($data['type']) {
+            case 'photo':
+                return InputPaidMediaPhoto::fromResponse($data);
+            case 'video':
+                return InputPaidMediaVideo::fromResponse($data);
+            default:
+                throw new InvalidArgumentException('Unknown input paid media type: ' . $data['type']);
+        }
+    }
+
+    protected $type;
+    protected $media;
+
+    public function __construct($media = null)
+    {
+        if ($media !== null) {
+            $this->media = $media;
+        }
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+
+    public function getMedia()
+    {
+        return $this->media;
+    }
+
+    public function setMedia($media)
+    {
+        $this->media = $media;
+    }
+}

--- a/src/Types/InputPaidMediaPhoto.php
+++ b/src/Types/InputPaidMediaPhoto.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class InputPaidMediaPhoto
+ * The paid media to send is a photo.
+ */
+class InputPaidMediaPhoto extends InputPaidMedia
+{
+    protected static $requiredParams = ['type', 'media'];
+
+    protected static $map = [
+        'type' => true,
+        'media' => true
+    ];
+
+    protected $type = 'photo';
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+}

--- a/src/Types/InputPaidMediaVideo.php
+++ b/src/Types/InputPaidMediaVideo.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class InputPaidMediaVideo
+ * The paid media to send is a video.
+ */
+class InputPaidMediaVideo extends InputPaidMedia
+{
+    protected static $requiredParams = ['type', 'media'];
+
+    protected static $map = [
+        'type' => true,
+        'media' => true,
+        'thumbnail' => true,
+        'cover' => true,
+        'start_timestamp' => true,
+        'width' => true,
+        'height' => true,
+        'duration' => true,
+        'supports_streaming' => true
+    ];
+
+    protected $type = 'video';
+    protected $thumbnail;
+    protected $cover;
+    protected $startTimestamp;
+    protected $width;
+    protected $height;
+    protected $duration;
+    protected $supportsStreaming;
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+
+    public function getThumbnail()
+    {
+        return $this->thumbnail;
+    }
+
+    public function setThumbnail($thumbnail)
+    {
+        $this->thumbnail = $thumbnail;
+    }
+
+    public function getCover()
+    {
+        return $this->cover;
+    }
+
+    public function setCover($cover)
+    {
+        $this->cover = $cover;
+    }
+
+    public function getStartTimestamp()
+    {
+        return $this->startTimestamp;
+    }
+
+    public function setStartTimestamp($start)
+    {
+        $this->startTimestamp = $start;
+    }
+
+    public function getWidth()
+    {
+        return $this->width;
+    }
+
+    public function setWidth($width)
+    {
+        $this->width = $width;
+    }
+
+    public function getHeight()
+    {
+        return $this->height;
+    }
+
+    public function setHeight($height)
+    {
+        $this->height = $height;
+    }
+
+    public function getDuration()
+    {
+        return $this->duration;
+    }
+
+    public function setDuration($duration)
+    {
+        $this->duration = $duration;
+    }
+
+    public function getSupportsStreaming()
+    {
+        return $this->supportsStreaming;
+    }
+
+    public function setSupportsStreaming($supports)
+    {
+        $this->supportsStreaming = $supports;
+    }
+}

--- a/src/Types/InputProfilePhoto.php
+++ b/src/Types/InputProfilePhoto.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\InvalidArgumentException;
+use TelegramBot\\Api\\TypeInterface;
+
+abstract class InputProfilePhoto extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['type'];
+
+    protected static $map = [
+        'type' => true
+    ];
+
+    /**
+     * @psalm-suppress LessSpecificReturnType,MoreSpecificReturnType
+     */
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        switch ($data['type']) {
+            case 'static':
+                return InputProfilePhotoStatic::fromResponse($data);
+            case 'animated':
+                return InputProfilePhotoAnimated::fromResponse($data);
+            default:
+                throw new InvalidArgumentException('Unknown input profile photo type: ' . $data['type']);
+        }
+    }
+
+    protected $type;
+    protected $photo;
+
+    public function __construct($photo = null)
+    {
+        if ($photo !== null) {
+            $this->photo = $photo;
+        }
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+
+    public function getPhoto()
+    {
+        return $this->photo;
+    }
+
+    public function setPhoto($photo)
+    {
+        $this->photo = $photo;
+    }
+}

--- a/src/Types/InputProfilePhotoAnimated.php
+++ b/src/Types/InputProfilePhotoAnimated.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class InputProfilePhotoAnimated
+ * An animated profile photo in the MPEG4 format.
+ */
+class InputProfilePhotoAnimated extends InputProfilePhoto
+{
+    protected static $requiredParams = ['type', 'animation'];
+
+    protected static $map = [
+        'type' => true,
+        'animation' => true,
+        'main_frame_timestamp' => true
+    ];
+
+    protected $type = 'animated';
+    protected $animation;
+    protected $mainFrameTimestamp;
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+
+    public function getAnimation()
+    {
+        return $this->animation;
+    }
+
+    public function setAnimation($animation)
+    {
+        $this->animation = $animation;
+    }
+
+    public function getMainFrameTimestamp()
+    {
+        return $this->mainFrameTimestamp;
+    }
+
+    public function setMainFrameTimestamp($ts)
+    {
+        $this->mainFrameTimestamp = $ts;
+    }
+}

--- a/src/Types/InputProfilePhotoStatic.php
+++ b/src/Types/InputProfilePhotoStatic.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class InputProfilePhotoStatic
+ * A static profile photo in the .JPG format.
+ */
+class InputProfilePhotoStatic extends InputProfilePhoto
+{
+    protected static $requiredParams = ['type', 'photo'];
+
+    protected static $map = [
+        'type' => true,
+        'photo' => true
+    ];
+
+    protected $type = 'static';
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+}

--- a/src/Types/InputStoryContent.php
+++ b/src/Types/InputStoryContent.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\InvalidArgumentException;
+use TelegramBot\\Api\\TypeInterface;
+
+abstract class InputStoryContent extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['type', 'photo'];
+
+    /**
+     * @psalm-suppress LessSpecificReturnType,MoreSpecificReturnType
+     */
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        switch ($data['type']) {
+            case 'photo':
+                return InputStoryContentPhoto::fromResponse($data);
+            case 'video':
+                return InputStoryContentVideo::fromResponse($data);
+            default:
+                throw new InvalidArgumentException('Unknown input story content type: ' . $data['type']);
+        }
+    }
+
+    protected $type;
+    protected $photo;
+
+    public function __construct($photo = null)
+    {
+        if ($photo !== null) {
+            $this->photo = $photo;
+        }
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+
+    public function getPhoto()
+    {
+        return $this->photo;
+    }
+
+    public function setPhoto($photo)
+    {
+        $this->photo = $photo;
+    }
+}

--- a/src/Types/InputStoryContentPhoto.php
+++ b/src/Types/InputStoryContentPhoto.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class InputStoryContentPhoto
+ * Describes a photo to post as a story.
+ */
+class InputStoryContentPhoto extends InputStoryContent
+{
+    protected static $requiredParams = ['type', 'photo'];
+
+    protected static $map = [
+        'type' => true,
+        'photo' => true
+    ];
+
+    protected $type = 'photo';
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+}

--- a/src/Types/InputStoryContentVideo.php
+++ b/src/Types/InputStoryContentVideo.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class InputStoryContentVideo
+ * Describes a video to post as a story.
+ */
+class InputStoryContentVideo extends InputStoryContent
+{
+    protected static $requiredParams = ['type', 'video'];
+
+    protected static $map = [
+        'type' => true,
+        'video' => true,
+        'duration' => true,
+        'cover_frame_timestamp' => true,
+        'is_animation' => true
+    ];
+
+    protected $type = 'video';
+    protected $video;
+    protected $duration;
+    protected $coverFrameTimestamp;
+    protected $isAnimation;
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+
+    public function getVideo()
+    {
+        return $this->video;
+    }
+
+    public function setVideo($video)
+    {
+        $this->video = $video;
+    }
+
+    public function getDuration()
+    {
+        return $this->duration;
+    }
+
+    public function setDuration($duration)
+    {
+        $this->duration = $duration;
+    }
+
+    public function getCoverFrameTimestamp()
+    {
+        return $this->coverFrameTimestamp;
+    }
+
+    public function setCoverFrameTimestamp($ts)
+    {
+        $this->coverFrameTimestamp = $ts;
+    }
+
+    public function getIsAnimation()
+    {
+        return $this->isAnimation;
+    }
+
+    public function setIsAnimation($isAnimation)
+    {
+        $this->isAnimation = $isAnimation;
+    }
+}

--- a/src/Types/LocationAddress.php
+++ b/src/Types/LocationAddress.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+
+/**
+ * Class LocationAddress
+ * Describes the physical address of a location.
+ */
+class LocationAddress extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['country_code'];
+
+    protected static $map = [
+        'country_code' => true,
+        'state' => true,
+        'city' => true,
+        'street' => true
+    ];
+
+    protected $countryCode;
+    protected $state;
+    protected $city;
+    protected $street;
+
+    public function getCountryCode()
+    {
+        return $this->countryCode;
+    }
+
+    public function setCountryCode($countryCode)
+    {
+        $this->countryCode = $countryCode;
+    }
+
+    public function getState()
+    {
+        return $this->state;
+    }
+
+    public function setState($state)
+    {
+        $this->state = $state;
+    }
+
+    public function getCity()
+    {
+        return $this->city;
+    }
+
+    public function setCity($city)
+    {
+        $this->city = $city;
+    }
+
+    public function getStreet()
+    {
+        return $this->street;
+    }
+
+    public function setStreet($street)
+    {
+        $this->street = $street;
+    }
+}

--- a/src/Types/MenuButton.php
+++ b/src/Types/MenuButton.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\InvalidArgumentException;
+use TelegramBot\\Api\\TypeInterface;
+
+abstract class MenuButton extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['type'];
+
+    protected static $map = [
+        'type' => true
+    ];
+
+    /**
+     * @psalm-suppress LessSpecificReturnType,MoreSpecificReturnType
+     */
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        switch ($data['type']) {
+            case 'commands':
+                return MenuButtonCommands::fromResponse($data);
+            case 'web_app':
+                return MenuButtonWebApp::fromResponse($data);
+            case 'default':
+                return MenuButtonDefault::fromResponse($data);
+            default:
+                throw new InvalidArgumentException('Unknown menu button type: ' . $data['type']);
+        }
+    }
+
+    protected $type;
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+}

--- a/src/Types/MenuButtonCommands.php
+++ b/src/Types/MenuButtonCommands.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class MenuButtonCommands
+ * Represents a menu button opening the bot's list of commands.
+ */
+class MenuButtonCommands extends MenuButton
+{
+    protected static $requiredParams = ['type'];
+
+    protected static $map = [
+        'type' => true
+    ];
+
+    protected $type = 'commands';
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+}

--- a/src/Types/MenuButtonDefault.php
+++ b/src/Types/MenuButtonDefault.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class MenuButtonDefault
+ * Describes that no specific value for the menu button was set.
+ */
+class MenuButtonDefault extends MenuButton
+{
+    protected static $requiredParams = ['type'];
+
+    protected static $map = [
+        'type' => true
+    ];
+
+    protected $type = 'default';
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+}

--- a/src/Types/MenuButtonWebApp.php
+++ b/src/Types/MenuButtonWebApp.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class MenuButtonWebApp
+ * Represents a menu button launching a Web App.
+ */
+class MenuButtonWebApp extends MenuButton
+{
+    protected static $requiredParams = ['type', 'text', 'web_app'];
+
+    protected static $map = [
+        'type' => true,
+        'text' => true,
+        'web_app' => WebAppInfo::class
+    ];
+
+    protected $type = 'web_app';
+    protected $text;
+    protected $webApp;
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+
+    public function getText()
+    {
+        return $this->text;
+    }
+
+    public function setText($text)
+    {
+        $this->text = $text;
+    }
+
+    public function getWebApp()
+    {
+        return $this->webApp;
+    }
+
+    public function setWebApp($webApp)
+    {
+        $this->webApp = $webApp;
+    }
+}

--- a/src/Types/OwnedGift.php
+++ b/src/Types/OwnedGift.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+use TelegramBot\\Api\\InvalidArgumentException;
+
+class OwnedGift extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['type', 'gift', 'send_date'];
+
+    protected static $map = [
+        'type' => true,
+        'gift' => true,
+        'owned_gift_id' => true,
+        'sender_user' => User::class,
+        'send_date' => true,
+    ];
+
+    protected $type;
+    protected $gift;
+    protected $ownedGiftId;
+    protected $senderUser;
+    protected $sendDate;
+
+    /**
+     * @psalm-suppress LessSpecificReturnStatement,MoreSpecificReturnType
+     */
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        switch ($data['type']) {
+            case 'regular':
+                return OwnedGiftRegular::fromResponse($data);
+            case 'unique':
+                return OwnedGiftUnique::fromResponse($data);
+            default:
+                throw new InvalidArgumentException('Unknown owned gift type: ' . $data['type']);
+        }
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+
+    public function getGift()
+    {
+        return $this->gift;
+    }
+
+    public function setGift($gift)
+    {
+        $this->gift = $gift;
+    }
+
+    public function getOwnedGiftId()
+    {
+        return $this->ownedGiftId;
+    }
+
+    public function setOwnedGiftId($ownedGiftId)
+    {
+        $this->ownedGiftId = $ownedGiftId;
+    }
+
+    public function getSenderUser()
+    {
+        return $this->senderUser;
+    }
+
+    public function setSenderUser($senderUser)
+    {
+        $this->senderUser = $senderUser;
+    }
+
+    public function getSendDate()
+    {
+        return $this->sendDate;
+    }
+
+    public function setSendDate($sendDate)
+    {
+        $this->sendDate = $sendDate;
+    }
+}

--- a/src/Types/OwnedGiftRegular.php
+++ b/src/Types/OwnedGiftRegular.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+class OwnedGiftRegular extends OwnedGift
+{
+    protected static $requiredParams = ['type', 'gift', 'send_date'];
+
+    protected static $map = [
+        'type' => true,
+        'gift' => Gift::class,
+        'owned_gift_id' => true,
+        'sender_user' => User::class,
+        'send_date' => true,
+        'text' => true,
+        'entities' => ArrayOfMessageEntity::class,
+        'is_private' => true,
+        'is_saved' => true,
+        'can_be_upgraded' => true,
+        'was_refunded' => true,
+        'convert_star_count' => true,
+        'prepaid_upgrade_star_count' => true,
+    ];
+
+    protected $text;
+    protected $entities;
+    protected $isPrivate;
+    protected $isSaved;
+    protected $canBeUpgraded;
+    protected $wasRefunded;
+    protected $convertStarCount;
+    protected $prepaidUpgradeStarCount;
+    protected $type = 'regular';
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+
+    public function getText()
+    {
+        return $this->text;
+    }
+
+    public function setText($text)
+    {
+        $this->text = $text;
+    }
+
+    public function getEntities()
+    {
+        return $this->entities;
+    }
+
+    public function setEntities($entities)
+    {
+        $this->entities = $entities;
+    }
+
+    public function getIsPrivate()
+    {
+        return $this->isPrivate;
+    }
+
+    public function setIsPrivate($isPrivate)
+    {
+        $this->isPrivate = $isPrivate;
+    }
+
+    public function getIsSaved()
+    {
+        return $this->isSaved;
+    }
+
+    public function setIsSaved($isSaved)
+    {
+        $this->isSaved = $isSaved;
+    }
+
+    public function getCanBeUpgraded()
+    {
+        return $this->canBeUpgraded;
+    }
+
+    public function setCanBeUpgraded($canBeUpgraded)
+    {
+        $this->canBeUpgraded = $canBeUpgraded;
+    }
+
+    public function getWasRefunded()
+    {
+        return $this->wasRefunded;
+    }
+
+    public function setWasRefunded($wasRefunded)
+    {
+        $this->wasRefunded = $wasRefunded;
+    }
+
+    public function getConvertStarCount()
+    {
+        return $this->convertStarCount;
+    }
+
+    public function setConvertStarCount($convertStarCount)
+    {
+        $this->convertStarCount = $convertStarCount;
+    }
+
+    public function getPrepaidUpgradeStarCount()
+    {
+        return $this->prepaidUpgradeStarCount;
+    }
+
+    public function setPrepaidUpgradeStarCount($prepaidUpgradeStarCount)
+    {
+        $this->prepaidUpgradeStarCount = $prepaidUpgradeStarCount;
+    }
+}

--- a/src/Types/OwnedGiftUnique.php
+++ b/src/Types/OwnedGiftUnique.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+class OwnedGiftUnique extends OwnedGift
+{
+    protected static $requiredParams = ['type', 'gift', 'send_date'];
+
+    protected static $map = [
+        'type' => true,
+        'gift' => UniqueGift::class,
+        'owned_gift_id' => true,
+        'sender_user' => User::class,
+        'send_date' => true,
+        'is_saved' => true,
+        'can_be_transferred' => true,
+        'transfer_star_count' => true,
+    ];
+
+    protected $isSaved;
+    protected $canBeTransferred;
+    protected $transferStarCount;
+    protected $type = 'unique';
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+
+    public function getIsSaved()
+    {
+        return $this->isSaved;
+    }
+
+    public function setIsSaved($isSaved)
+    {
+        $this->isSaved = $isSaved;
+    }
+
+    public function getCanBeTransferred()
+    {
+        return $this->canBeTransferred;
+    }
+
+    public function setCanBeTransferred($canBeTransferred)
+    {
+        $this->canBeTransferred = $canBeTransferred;
+    }
+
+    public function getTransferStarCount()
+    {
+        return $this->transferStarCount;
+    }
+
+    public function setTransferStarCount($transferStarCount)
+    {
+        $this->transferStarCount = $transferStarCount;
+    }
+}

--- a/src/Types/OwnedGifts.php
+++ b/src/Types/OwnedGifts.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+
+class OwnedGifts extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['total_count', 'gifts'];
+
+    protected static $map = [
+        'total_count' => true,
+        'gifts' => ArrayOfOwnedGift::class,
+        'next_offset' => true,
+    ];
+
+    protected $totalCount;
+    protected $gifts;
+    protected $nextOffset;
+
+    public function getTotalCount()
+    {
+        return $this->totalCount;
+    }
+
+    public function setTotalCount($totalCount)
+    {
+        $this->totalCount = $totalCount;
+    }
+
+    public function getGifts()
+    {
+        return $this->gifts;
+    }
+
+    public function setGifts($gifts)
+    {
+        $this->gifts = $gifts;
+    }
+
+    public function getNextOffset()
+    {
+        return $this->nextOffset;
+    }
+
+    public function setNextOffset($nextOffset)
+    {
+        $this->nextOffset = $nextOffset;
+    }
+}

--- a/src/Types/PaidMedia.php
+++ b/src/Types/PaidMedia.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\InvalidArgumentException;
+use TelegramBot\\Api\\TypeInterface;
+
+abstract class PaidMedia extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['type'];
+
+    protected static $map = ['type' => true];
+
+    /**
+     * @psalm-suppress LessSpecificReturnStatement,MoreSpecificReturnType
+     */
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        switch ($data['type']) {
+            case 'preview':
+                return PaidMediaPreview::fromResponse($data);
+            case 'photo':
+                return PaidMediaPhoto::fromResponse($data);
+            case 'video':
+                return PaidMediaVideo::fromResponse($data);
+            default:
+                throw new InvalidArgumentException('Unknown paid media type: ' . $data['type']);
+        }
+    }
+
+    protected $type;
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+}

--- a/src/Types/PaidMediaInfo.php
+++ b/src/Types/PaidMediaInfo.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+
+/**
+ * Class PaidMediaInfo
+ * Describes the paid media added to a message.
+ */
+class PaidMediaInfo extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['star_count', 'paid_media'];
+
+    protected static $map = [
+        'star_count' => true,
+        'paid_media' => PaidMedia::class
+    ];
+
+    protected $starCount;
+    protected $paidMedia;
+
+    public function getStarCount()
+    {
+        return $this->starCount;
+    }
+
+    public function setStarCount($starCount)
+    {
+        $this->starCount = $starCount;
+    }
+
+    public function getPaidMedia()
+    {
+        return $this->paidMedia;
+    }
+
+    public function setPaidMedia($paidMedia)
+    {
+        $this->paidMedia = $paidMedia;
+    }
+}

--- a/src/Types/PaidMediaPhoto.php
+++ b/src/Types/PaidMediaPhoto.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class PaidMediaPhoto
+ * The paid media is a photo.
+ */
+class PaidMediaPhoto extends PaidMedia
+{
+    protected static $requiredParams = ['type', 'photo'];
+
+    protected static $map = [
+        'type' => true,
+        'photo' => ArrayOfPhotoSize::class
+    ];
+
+    protected $type = 'photo';
+    protected $photo;
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+
+    public function getPhoto()
+    {
+        return $this->photo;
+    }
+
+    public function setPhoto($photo)
+    {
+        $this->photo = $photo;
+    }
+}

--- a/src/Types/PaidMediaPreview.php
+++ b/src/Types/PaidMediaPreview.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class PaidMediaPreview
+ * The paid media isn't available before the payment.
+ */
+class PaidMediaPreview extends PaidMedia
+{
+    protected static $map = [
+        'type' => true,
+        'width' => true,
+        'height' => true,
+        'duration' => true
+    ];
+
+    protected static $requiredParams = ['type'];
+
+    protected $type = 'preview';
+    protected $width;
+    protected $height;
+    protected $duration;
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+
+    public function getWidth()
+    {
+        return $this->width;
+    }
+
+    public function setWidth($width)
+    {
+        $this->width = $width;
+    }
+
+    public function getHeight()
+    {
+        return $this->height;
+    }
+
+    public function setHeight($height)
+    {
+        $this->height = $height;
+    }
+
+    public function getDuration()
+    {
+        return $this->duration;
+    }
+
+    public function setDuration($duration)
+    {
+        $this->duration = $duration;
+    }
+}

--- a/src/Types/PaidMediaVideo.php
+++ b/src/Types/PaidMediaVideo.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class PaidMediaVideo
+ * The paid media is a video.
+ */
+class PaidMediaVideo extends PaidMedia
+{
+    protected static $requiredParams = ['type', 'video'];
+
+    protected static $map = [
+        'type' => true,
+        'video' => Video::class
+    ];
+
+    protected $type = 'video';
+    protected $video;
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+
+    public function getVideo()
+    {
+        return $this->video;
+    }
+
+    public function setVideo($video)
+    {
+        $this->video = $video;
+    }
+}

--- a/src/Types/PaidMessagePriceChanged.php
+++ b/src/Types/PaidMessagePriceChanged.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+
+/**
+ * Class PaidMessagePriceChanged
+ * Describes a service message about a change in the price of paid messages.
+ */
+class PaidMessagePriceChanged extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['paid_message_star_count'];
+
+    protected static $map = [
+        'paid_message_star_count' => true
+    ];
+
+    protected $paidMessageStarCount;
+
+    public function getPaidMessageStarCount()
+    {
+        return $this->paidMessageStarCount;
+    }
+
+    public function setPaidMessageStarCount($count)
+    {
+        $this->paidMessageStarCount = $count;
+    }
+}

--- a/src/Types/ReactionTypePaid.php
+++ b/src/Types/ReactionTypePaid.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class ReactionTypePaid
+ * The reaction is paid.
+ */
+class ReactionTypePaid extends ReactionType
+{
+    protected static $map = ['type' => true];
+    protected static $requiredParams = ['type'];
+
+    protected $type = 'paid';
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+}

--- a/src/Types/StarAmount.php
+++ b/src/Types/StarAmount.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+
+class StarAmount extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['amount'];
+
+    protected static $map = [
+        'amount' => true,
+        'nanostar_amount' => true,
+    ];
+
+    protected $amount;
+    protected $nanostarAmount;
+
+    public function getAmount()
+    {
+        return $this->amount;
+    }
+
+    public function setAmount($amount)
+    {
+        $this->amount = $amount;
+    }
+
+    public function getNanostarAmount()
+    {
+        return $this->nanostarAmount;
+    }
+
+    public function setNanostarAmount($nanostarAmount)
+    {
+        $this->nanostarAmount = $nanostarAmount;
+    }
+}

--- a/src/Types/StoryArea.php
+++ b/src/Types/StoryArea.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+
+/**
+ * Class StoryArea
+ * Describes a clickable area on a story media.
+ */
+class StoryArea extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['position', 'type'];
+
+    protected static $map = [
+        'position' => StoryAreaPosition::class,
+        'type' => StoryAreaType::class
+    ];
+
+    protected $position;
+    protected $type;
+
+    public function getPosition()
+    {
+        return $this->position;
+    }
+
+    public function setPosition($position)
+    {
+        $this->position = $position;
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+}

--- a/src/Types/StoryAreaPosition.php
+++ b/src/Types/StoryAreaPosition.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+
+/**
+ * Class StoryAreaPosition
+ * Describes the position of a clickable area within a story.
+ */
+class StoryAreaPosition extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = [
+        'x_percentage',
+        'y_percentage',
+        'width_percentage',
+        'height_percentage',
+        'rotation_angle',
+        'corner_radius_percentage'
+    ];
+
+    protected static $map = [
+        'x_percentage' => true,
+        'y_percentage' => true,
+        'width_percentage' => true,
+        'height_percentage' => true,
+        'rotation_angle' => true,
+        'corner_radius_percentage' => true
+    ];
+
+    protected $xPercentage;
+    protected $yPercentage;
+    protected $widthPercentage;
+    protected $heightPercentage;
+    protected $rotationAngle;
+    protected $cornerRadiusPercentage;
+
+    public function getXPercentage()
+    {
+        return $this->xPercentage;
+    }
+
+    public function setXPercentage($xPercentage)
+    {
+        $this->xPercentage = $xPercentage;
+    }
+
+    public function getYPercentage()
+    {
+        return $this->yPercentage;
+    }
+
+    public function setYPercentage($yPercentage)
+    {
+        $this->yPercentage = $yPercentage;
+    }
+
+    public function getWidthPercentage()
+    {
+        return $this->widthPercentage;
+    }
+
+    public function setWidthPercentage($widthPercentage)
+    {
+        $this->widthPercentage = $widthPercentage;
+    }
+
+    public function getHeightPercentage()
+    {
+        return $this->heightPercentage;
+    }
+
+    public function setHeightPercentage($heightPercentage)
+    {
+        $this->heightPercentage = $heightPercentage;
+    }
+
+    public function getRotationAngle()
+    {
+        return $this->rotationAngle;
+    }
+
+    public function setRotationAngle($rotationAngle)
+    {
+        $this->rotationAngle = $rotationAngle;
+    }
+
+    public function getCornerRadiusPercentage()
+    {
+        return $this->cornerRadiusPercentage;
+    }
+
+    public function setCornerRadiusPercentage($cornerRadiusPercentage)
+    {
+        $this->cornerRadiusPercentage = $cornerRadiusPercentage;
+    }
+}

--- a/src/Types/StoryAreaType.php
+++ b/src/Types/StoryAreaType.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\InvalidArgumentException;
+use TelegramBot\\Api\\TypeInterface;
+
+abstract class StoryAreaType extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['type'];
+
+    protected static $map = [
+        'type' => true
+    ];
+
+    /**
+     * @psalm-suppress LessSpecificReturnStatement,MoreSpecificReturnType
+     */
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        switch ($data['type']) {
+            case 'location':
+                return StoryAreaTypeLocation::fromResponse($data);
+            case 'suggested_reaction':
+                return StoryAreaTypeSuggestedReaction::fromResponse($data);
+            case 'link':
+                return StoryAreaTypeLink::fromResponse($data);
+            case 'weather':
+                return StoryAreaTypeWeather::fromResponse($data);
+            case 'unique_gift':
+                return StoryAreaTypeUniqueGift::fromResponse($data);
+            default:
+                throw new InvalidArgumentException('Unknown story area type: ' . $data['type']);
+        }
+    }
+
+    protected $type;
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+}

--- a/src/Types/StoryAreaTypeLink.php
+++ b/src/Types/StoryAreaTypeLink.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class StoryAreaTypeLink
+ * Describes a story area pointing to a link.
+ */
+class StoryAreaTypeLink extends StoryAreaType
+{
+    protected static $requiredParams = ['type', 'url'];
+
+    protected static $map = [
+        'type' => true,
+        'url' => true
+    ];
+
+    protected $type = 'link';
+    protected $url;
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    public function setUrl($url)
+    {
+        $this->url = $url;
+    }
+}

--- a/src/Types/StoryAreaTypeLocation.php
+++ b/src/Types/StoryAreaTypeLocation.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class StoryAreaTypeLocation
+ * Describes a story area pointing to a location.
+ */
+class StoryAreaTypeLocation extends StoryAreaType
+{
+    protected static $requiredParams = ['type', 'latitude', 'longitude'];
+
+    protected static $map = [
+        'type' => true,
+        'latitude' => true,
+        'longitude' => true,
+        'address' => LocationAddress::class
+    ];
+
+    protected $type = 'location';
+    protected $latitude;
+    protected $longitude;
+    protected $address;
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+
+    public function getLatitude()
+    {
+        return $this->latitude;
+    }
+
+    public function setLatitude($latitude)
+    {
+        $this->latitude = $latitude;
+    }
+
+    public function getLongitude()
+    {
+        return $this->longitude;
+    }
+
+    public function setLongitude($longitude)
+    {
+        $this->longitude = $longitude;
+    }
+
+    public function getAddress()
+    {
+        return $this->address;
+    }
+
+    public function setAddress($address)
+    {
+        $this->address = $address;
+    }
+}

--- a/src/Types/StoryAreaTypeSuggestedReaction.php
+++ b/src/Types/StoryAreaTypeSuggestedReaction.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class StoryAreaTypeSuggestedReaction
+ * Describes a story area pointing to a suggested reaction.
+ */
+class StoryAreaTypeSuggestedReaction extends StoryAreaType
+{
+    protected static $requiredParams = ['type', 'reaction_type'];
+
+    protected static $map = [
+        'type' => true,
+        'reaction_type' => ReactionType::class,
+        'is_dark' => true,
+        'is_flipped' => true
+    ];
+
+    protected $type = 'suggested_reaction';
+    protected $reactionType;
+    protected $isDark;
+    protected $isFlipped;
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+
+    public function getReactionType()
+    {
+        return $this->reactionType;
+    }
+
+    public function setReactionType($reactionType)
+    {
+        $this->reactionType = $reactionType;
+    }
+
+    public function getIsDark()
+    {
+        return $this->isDark;
+    }
+
+    public function setIsDark($isDark)
+    {
+        $this->isDark = $isDark;
+    }
+
+    public function getIsFlipped()
+    {
+        return $this->isFlipped;
+    }
+
+    public function setIsFlipped($isFlipped)
+    {
+        $this->isFlipped = $isFlipped;
+    }
+}

--- a/src/Types/StoryAreaTypeUniqueGift.php
+++ b/src/Types/StoryAreaTypeUniqueGift.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class StoryAreaTypeUniqueGift
+ * Describes a story area pointing to a unique gift.
+ */
+class StoryAreaTypeUniqueGift extends StoryAreaType
+{
+    protected static $requiredParams = ['type', 'name'];
+
+    protected static $map = [
+        'type' => true,
+        'name' => true
+    ];
+
+    protected $type = 'unique_gift';
+    protected $name;
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/src/Types/StoryAreaTypeWeather.php
+++ b/src/Types/StoryAreaTypeWeather.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+/**
+ * Class StoryAreaTypeWeather
+ * Describes a story area containing weather information.
+ */
+class StoryAreaTypeWeather extends StoryAreaType
+{
+    protected static $requiredParams = ['type', 'temperature', 'emoji', 'background_color'];
+
+    protected static $map = [
+        'type' => true,
+        'temperature' => true,
+        'emoji' => true,
+        'background_color' => true
+    ];
+
+    protected $type = 'weather';
+    protected $temperature;
+    protected $emoji;
+    protected $backgroundColor;
+
+    public static function fromResponse($data)
+    {
+        self::validate($data);
+        $instance = new static();
+        $instance->map($data);
+        return $instance;
+    }
+
+    public function getTemperature()
+    {
+        return $this->temperature;
+    }
+
+    public function setTemperature($temperature)
+    {
+        $this->temperature = $temperature;
+    }
+
+    public function getEmoji()
+    {
+        return $this->emoji;
+    }
+
+    public function setEmoji($emoji)
+    {
+        $this->emoji = $emoji;
+    }
+
+    public function getBackgroundColor()
+    {
+        return $this->backgroundColor;
+    }
+
+    public function setBackgroundColor($backgroundColor)
+    {
+        $this->backgroundColor = $backgroundColor;
+    }
+}

--- a/src/Types/UniqueGift.php
+++ b/src/Types/UniqueGift.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+
+class UniqueGift extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['base_name', 'name', 'number', 'model', 'symbol', 'backdrop'];
+
+    protected static $map = [
+        'base_name' => true,
+        'name' => true,
+        'number' => true,
+        'model' => UniqueGiftModel::class,
+        'symbol' => UniqueGiftSymbol::class,
+        'backdrop' => UniqueGiftBackdrop::class,
+    ];
+
+    protected $baseName;
+    protected $name;
+    protected $number;
+    protected $model;
+    protected $symbol;
+    protected $backdrop;
+
+    public function getBaseName()
+    {
+        return $this->baseName;
+    }
+
+    public function setBaseName($baseName)
+    {
+        $this->baseName = $baseName;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getNumber()
+    {
+        return $this->number;
+    }
+
+    public function setNumber($number)
+    {
+        $this->number = $number;
+    }
+
+    public function getModel()
+    {
+        return $this->model;
+    }
+
+    public function setModel($model)
+    {
+        $this->model = $model;
+    }
+
+    public function getSymbol()
+    {
+        return $this->symbol;
+    }
+
+    public function setSymbol($symbol)
+    {
+        $this->symbol = $symbol;
+    }
+
+    public function getBackdrop()
+    {
+        return $this->backdrop;
+    }
+
+    public function setBackdrop($backdrop)
+    {
+        $this->backdrop = $backdrop;
+    }
+}

--- a/src/Types/UniqueGiftBackdrop.php
+++ b/src/Types/UniqueGiftBackdrop.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+
+class UniqueGiftBackdrop extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['name', 'colors', 'rarity_per_mille'];
+
+    protected static $map = [
+        'name' => true,
+        'colors' => UniqueGiftBackdropColors::class,
+        'rarity_per_mille' => true,
+    ];
+
+    protected $name;
+    protected $colors;
+    protected $rarityPerMille;
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getColors()
+    {
+        return $this->colors;
+    }
+
+    public function setColors($colors)
+    {
+        $this->colors = $colors;
+    }
+
+    public function getRarityPerMille()
+    {
+        return $this->rarityPerMille;
+    }
+
+    public function setRarityPerMille($rarityPerMille)
+    {
+        $this->rarityPerMille = $rarityPerMille;
+    }
+}

--- a/src/Types/UniqueGiftBackdropColors.php
+++ b/src/Types/UniqueGiftBackdropColors.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+
+class UniqueGiftBackdropColors extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['center_color', 'edge_color', 'symbol_color', 'text_color'];
+
+    protected static $map = [
+        'center_color' => true,
+        'edge_color' => true,
+        'symbol_color' => true,
+        'text_color' => true,
+    ];
+
+    protected $centerColor;
+    protected $edgeColor;
+    protected $symbolColor;
+    protected $textColor;
+
+    public function getCenterColor()
+    {
+        return $this->centerColor;
+    }
+
+    public function setCenterColor($centerColor)
+    {
+        $this->centerColor = $centerColor;
+    }
+
+    public function getEdgeColor()
+    {
+        return $this->edgeColor;
+    }
+
+    public function setEdgeColor($edgeColor)
+    {
+        $this->edgeColor = $edgeColor;
+    }
+
+    public function getSymbolColor()
+    {
+        return $this->symbolColor;
+    }
+
+    public function setSymbolColor($symbolColor)
+    {
+        $this->symbolColor = $symbolColor;
+    }
+
+    public function getTextColor()
+    {
+        return $this->textColor;
+    }
+
+    public function setTextColor($textColor)
+    {
+        $this->textColor = $textColor;
+    }
+}

--- a/src/Types/UniqueGiftInfo.php
+++ b/src/Types/UniqueGiftInfo.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+
+class UniqueGiftInfo extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['gift', 'origin'];
+
+    protected static $map = [
+        'gift' => UniqueGift::class,
+        'origin' => true,
+        'owned_gift_id' => true,
+        'transfer_star_count' => true,
+    ];
+
+    protected $gift;
+    protected $origin;
+    protected $ownedGiftId;
+    protected $transferStarCount;
+
+    public function getGift()
+    {
+        return $this->gift;
+    }
+
+    public function setGift($gift)
+    {
+        $this->gift = $gift;
+    }
+
+    public function getOrigin()
+    {
+        return $this->origin;
+    }
+
+    public function setOrigin($origin)
+    {
+        $this->origin = $origin;
+    }
+
+    public function getOwnedGiftId()
+    {
+        return $this->ownedGiftId;
+    }
+
+    public function setOwnedGiftId($ownedGiftId)
+    {
+        $this->ownedGiftId = $ownedGiftId;
+    }
+
+    public function getTransferStarCount()
+    {
+        return $this->transferStarCount;
+    }
+
+    public function setTransferStarCount($transferStarCount)
+    {
+        $this->transferStarCount = $transferStarCount;
+    }
+}

--- a/src/Types/UniqueGiftModel.php
+++ b/src/Types/UniqueGiftModel.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+
+class UniqueGiftModel extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['name', 'sticker', 'rarity_per_mille'];
+
+    protected static $map = [
+        'name' => true,
+        'sticker' => Sticker::class,
+        'rarity_per_mille' => true,
+    ];
+
+    protected $name;
+    protected $sticker;
+    protected $rarityPerMille;
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getSticker()
+    {
+        return $this->sticker;
+    }
+
+    public function setSticker($sticker)
+    {
+        $this->sticker = $sticker;
+    }
+
+    public function getRarityPerMille()
+    {
+        return $this->rarityPerMille;
+    }
+
+    public function setRarityPerMille($rarityPerMille)
+    {
+        $this->rarityPerMille = $rarityPerMille;
+    }
+}

--- a/src/Types/UniqueGiftSymbol.php
+++ b/src/Types/UniqueGiftSymbol.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace TelegramBot\\Api\\Types;
+
+use TelegramBot\\Api\\BaseType;
+use TelegramBot\\Api\\TypeInterface;
+
+class UniqueGiftSymbol extends BaseType implements TypeInterface
+{
+    protected static $requiredParams = ['name', 'sticker', 'rarity_per_mille'];
+
+    protected static $map = [
+        'name' => true,
+        'sticker' => Sticker::class,
+        'rarity_per_mille' => true,
+    ];
+
+    protected $name;
+    protected $sticker;
+    protected $rarityPerMille;
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getSticker()
+    {
+        return $this->sticker;
+    }
+
+    public function setSticker($sticker)
+    {
+        $this->sticker = $sticker;
+    }
+
+    public function getRarityPerMille()
+    {
+        return $this->rarityPerMille;
+    }
+
+    public function setRarityPerMille($rarityPerMille)
+    {
+        $this->rarityPerMille = $rarityPerMille;
+    }
+}

--- a/tests/Types/AcceptedGiftTypesTest.php
+++ b/tests/Types/AcceptedGiftTypesTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace TelegramBot\Api\Test\Types;
+
+use TelegramBot\Api\Test\AbstractTypeTest;
+use TelegramBot\Api\Types\AcceptedGiftTypes;
+
+class AcceptedGiftTypesTest extends AbstractTypeTest
+{
+    protected static function getType()
+    {
+        return AcceptedGiftTypes::class;
+    }
+
+    public static function getMinResponse()
+    {
+        return [
+            'unlimited_gifts' => true,
+            'limited_gifts' => true,
+            'unique_gifts' => true,
+            'premium_subscription' => true,
+        ];
+    }
+
+    public static function getFullResponse()
+    {
+        return static::getMinResponse();
+    }
+
+    protected function assertMinItem($item)
+    {
+        $this->assertTrue($item->getUnlimitedGifts());
+        $this->assertTrue($item->getLimitedGifts());
+        $this->assertTrue($item->getUniqueGifts());
+        $this->assertTrue($item->getPremiumSubscription());
+    }
+
+    protected function assertFullItem($item)
+    {
+        $this->assertMinItem($item);
+    }
+}

--- a/tests/Types/GiftInfoTest.php
+++ b/tests/Types/GiftInfoTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace TelegramBot\Api\Test\Types;
+
+use TelegramBot\Api\Test\AbstractTypeTest;
+use TelegramBot\Api\Types\GiftInfo;
+
+class GiftInfoTest extends AbstractTypeTest
+{
+    protected static function getType()
+    {
+        return GiftInfo::class;
+    }
+
+    public static function getMinResponse()
+    {
+        return [
+            'gift' => GiftTest::getMinResponse(),
+        ];
+    }
+
+    public static function getFullResponse()
+    {
+        return [
+            'gift' => GiftTest::getMinResponse(),
+            'owned_gift_id' => 'id',
+            'convert_star_count' => 1,
+            'prepaid_upgrade_star_count' => 2,
+            'can_be_upgraded' => true,
+            'text' => 'hi',
+            'entities' => [MessageEntityTest::getMinResponse()],
+            'is_private' => true,
+        ];
+    }
+
+    protected function assertMinItem($item)
+    {
+        $this->assertEquals(GiftTest::createMinInstance(), $item->getGift());
+        $this->assertNull($item->getOwnedGiftId());
+        $this->assertNull($item->getConvertStarCount());
+        $this->assertNull($item->getPrepaidUpgradeStarCount());
+        $this->assertNull($item->getCanBeUpgraded());
+        $this->assertNull($item->getText());
+        $this->assertNull($item->getEntities());
+        $this->assertNull($item->getIsPrivate());
+    }
+
+    protected function assertFullItem($item)
+    {
+        $this->assertEquals(GiftTest::createMinInstance(), $item->getGift());
+        $this->assertEquals('id', $item->getOwnedGiftId());
+        $this->assertEquals(1, $item->getConvertStarCount());
+        $this->assertEquals(2, $item->getPrepaidUpgradeStarCount());
+        $this->assertTrue($item->getCanBeUpgraded());
+        $this->assertEquals('hi', $item->getText());
+        $this->assertEquals([MessageEntityTest::createMinInstance()], $item->getEntities());
+        $this->assertTrue($item->getIsPrivate());
+    }
+}

--- a/tests/Types/GiftTest.php
+++ b/tests/Types/GiftTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace TelegramBot\Api\Test\Types;
+
+use TelegramBot\Api\Test\AbstractTypeTest;
+use TelegramBot\Api\Types\Gift;
+
+class GiftTest extends AbstractTypeTest
+{
+    protected static function getType()
+    {
+        return Gift::class;
+    }
+
+    public static function getMinResponse()
+    {
+        return [
+            'id' => 'gift1',
+            'sticker' => StickerTest::getMinResponse(),
+            'star_count' => 10,
+        ];
+    }
+
+    public static function getFullResponse()
+    {
+        return [
+            'id' => 'gift1',
+            'sticker' => StickerTest::getMinResponse(),
+            'star_count' => 10,
+            'upgrade_star_count' => 5,
+            'total_count' => 100,
+            'remaining_count' => 50,
+        ];
+    }
+
+    protected function assertMinItem($item)
+    {
+        $this->assertEquals('gift1', $item->getId());
+        $this->assertEquals(StickerTest::createMinInstance(), $item->getSticker());
+        $this->assertEquals(10, $item->getStarCount());
+        $this->assertNull($item->getUpgradeStarCount());
+        $this->assertNull($item->getTotalCount());
+        $this->assertNull($item->getRemainingCount());
+    }
+
+    protected function assertFullItem($item)
+    {
+        $this->assertEquals('gift1', $item->getId());
+        $this->assertEquals(StickerTest::createMinInstance(), $item->getSticker());
+        $this->assertEquals(10, $item->getStarCount());
+        $this->assertEquals(5, $item->getUpgradeStarCount());
+        $this->assertEquals(100, $item->getTotalCount());
+        $this->assertEquals(50, $item->getRemainingCount());
+    }
+}

--- a/tests/Types/GiftsTest.php
+++ b/tests/Types/GiftsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace TelegramBot\Api\Test\Types;
+
+use TelegramBot\Api\Test\AbstractTypeTest;
+use TelegramBot\Api\Types\Gifts;
+
+class GiftsTest extends AbstractTypeTest
+{
+    protected static function getType()
+    {
+        return Gifts::class;
+    }
+
+    public static function getMinResponse()
+    {
+        return [
+            'gifts' => [
+                GiftTest::getMinResponse(),
+            ],
+        ];
+    }
+
+    public static function getFullResponse()
+    {
+        return [
+            'gifts' => [
+                GiftTest::getFullResponse(),
+            ],
+        ];
+    }
+
+    protected function assertMinItem($item)
+    {
+        $this->assertIsArray($item->getGifts());
+        $this->assertEquals([GiftTest::createMinInstance()], $item->getGifts());
+    }
+
+    protected function assertFullItem($item)
+    {
+        $this->assertIsArray($item->getGifts());
+        $this->assertEquals([GiftTest::createFullInstance()], $item->getGifts());
+    }
+}

--- a/tests/Types/OwnedGiftRegularTest.php
+++ b/tests/Types/OwnedGiftRegularTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace TelegramBot\Api\Test\Types;
+
+use TelegramBot\Api\Test\AbstractTypeTest;
+use TelegramBot\Api\Types\OwnedGiftRegular;
+
+class OwnedGiftRegularTest extends AbstractTypeTest
+{
+    protected static function getType()
+    {
+        return OwnedGiftRegular::class;
+    }
+
+    public static function getMinResponse()
+    {
+        return [
+            'type' => 'regular',
+            'gift' => GiftTest::getMinResponse(),
+            'send_date' => 1682343643,
+        ];
+    }
+
+    public static function getFullResponse()
+    {
+        return [
+            'type' => 'regular',
+            'gift' => GiftTest::getMinResponse(),
+            'owned_gift_id' => 'id',
+            'sender_user' => UserTest::getMinResponse(),
+            'send_date' => 1682343643,
+            'text' => 'hi',
+            'entities' => [MessageEntityTest::getMinResponse()],
+            'is_private' => true,
+            'is_saved' => true,
+            'can_be_upgraded' => true,
+            'was_refunded' => true,
+            'convert_star_count' => 1,
+            'prepaid_upgrade_star_count' => 2,
+        ];
+    }
+
+    protected function assertMinItem($item)
+    {
+        $this->assertEquals('regular', $item->getType());
+        $this->assertEquals(GiftTest::createMinInstance(), $item->getGift());
+        $this->assertEquals(1682343643, $item->getSendDate());
+        $this->assertNull($item->getOwnedGiftId());
+    }
+
+    protected function assertFullItem($item)
+    {
+        $this->assertEquals('regular', $item->getType());
+        $this->assertEquals(GiftTest::createMinInstance(), $item->getGift());
+        $this->assertEquals('id', $item->getOwnedGiftId());
+        $this->assertEquals(UserTest::createMinInstance(), $item->getSenderUser());
+        $this->assertEquals(1682343643, $item->getSendDate());
+        $this->assertEquals('hi', $item->getText());
+        $this->assertEquals([MessageEntityTest::createMinInstance()], $item->getEntities());
+        $this->assertTrue($item->getIsPrivate());
+        $this->assertTrue($item->getIsSaved());
+        $this->assertTrue($item->getCanBeUpgraded());
+        $this->assertTrue($item->getWasRefunded());
+        $this->assertEquals(1, $item->getConvertStarCount());
+        $this->assertEquals(2, $item->getPrepaidUpgradeStarCount());
+    }
+}

--- a/tests/Types/OwnedGiftUniqueTest.php
+++ b/tests/Types/OwnedGiftUniqueTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace TelegramBot\Api\Test\Types;
+
+use TelegramBot\Api\Test\AbstractTypeTest;
+use TelegramBot\Api\Types\OwnedGiftUnique;
+
+class OwnedGiftUniqueTest extends AbstractTypeTest
+{
+    protected static function getType()
+    {
+        return OwnedGiftUnique::class;
+    }
+
+    public static function getMinResponse()
+    {
+        return [
+            'type' => 'unique',
+            'gift' => UniqueGiftTest::getMinResponse(),
+            'send_date' => 1682343643,
+        ];
+    }
+
+    public static function getFullResponse()
+    {
+        return [
+            'type' => 'unique',
+            'gift' => UniqueGiftTest::getMinResponse(),
+            'owned_gift_id' => 'id',
+            'sender_user' => UserTest::getMinResponse(),
+            'send_date' => 1682343643,
+            'is_saved' => true,
+            'can_be_transferred' => true,
+            'transfer_star_count' => 3,
+        ];
+    }
+
+    protected function assertMinItem($item)
+    {
+        $this->assertEquals('unique', $item->getType());
+        $this->assertEquals(UniqueGiftTest::createMinInstance(), $item->getGift());
+        $this->assertEquals(1682343643, $item->getSendDate());
+        $this->assertNull($item->getOwnedGiftId());
+    }
+
+    protected function assertFullItem($item)
+    {
+        $this->assertEquals('unique', $item->getType());
+        $this->assertEquals(UniqueGiftTest::createMinInstance(), $item->getGift());
+        $this->assertEquals('id', $item->getOwnedGiftId());
+        $this->assertEquals(UserTest::createMinInstance(), $item->getSenderUser());
+        $this->assertEquals(1682343643, $item->getSendDate());
+        $this->assertTrue($item->getIsSaved());
+        $this->assertTrue($item->getCanBeTransferred());
+        $this->assertEquals(3, $item->getTransferStarCount());
+    }
+}

--- a/tests/Types/OwnedGiftsTest.php
+++ b/tests/Types/OwnedGiftsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace TelegramBot\Api\Test\Types;
+
+use TelegramBot\Api\Test\AbstractTypeTest;
+use TelegramBot\Api\Types\OwnedGifts;
+
+class OwnedGiftsTest extends AbstractTypeTest
+{
+    protected static function getType()
+    {
+        return OwnedGifts::class;
+    }
+
+    public static function getMinResponse()
+    {
+        return [
+            'total_count' => 1,
+            'gifts' => [OwnedGiftRegularTest::getMinResponse()],
+        ];
+    }
+
+    public static function getFullResponse()
+    {
+        return [
+            'total_count' => 2,
+            'gifts' => [OwnedGiftRegularTest::getMinResponse()],
+            'next_offset' => '1',
+        ];
+    }
+
+    protected function assertMinItem($item)
+    {
+        $this->assertEquals(1, $item->getTotalCount());
+        $this->assertEquals([OwnedGiftRegularTest::createMinInstance()], $item->getGifts());
+        $this->assertNull($item->getNextOffset());
+    }
+
+    protected function assertFullItem($item)
+    {
+        $this->assertEquals(2, $item->getTotalCount());
+        $this->assertEquals([OwnedGiftRegularTest::createMinInstance()], $item->getGifts());
+        $this->assertEquals('1', $item->getNextOffset());
+    }
+}

--- a/tests/Types/ReactionTypePaidTest.php
+++ b/tests/Types/ReactionTypePaidTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace TelegramBot\\Api\\Test\\Types;
+
+use TelegramBot\\Api\\Test\\AbstractTypeTest;
+use TelegramBot\\Api\\Types\\ReactionTypePaid;
+
+class ReactionTypePaidTest extends AbstractTypeTest
+{
+    protected static function getType()
+    {
+        return ReactionTypePaid::class;
+    }
+
+    public static function getMinResponse()
+    {
+        return [
+            'type' => 'paid'
+        ];
+    }
+
+    public static function getFullResponse()
+    {
+        return static::getMinResponse();
+    }
+
+    protected function assertMinItem($item)
+    {
+        $this->assertEquals('paid', $item->getType());
+    }
+
+    protected function assertFullItem($item)
+    {
+        $this->assertMinItem($item);
+    }
+}

--- a/tests/Types/StarAmountTest.php
+++ b/tests/Types/StarAmountTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace TelegramBot\Api\Test\Types;
+
+use TelegramBot\Api\Test\AbstractTypeTest;
+use TelegramBot\Api\Types\StarAmount;
+
+class StarAmountTest extends AbstractTypeTest
+{
+    protected static function getType()
+    {
+        return StarAmount::class;
+    }
+
+    public static function getMinResponse()
+    {
+        return [
+            'amount' => 1,
+        ];
+    }
+
+    public static function getFullResponse()
+    {
+        return [
+            'amount' => 2,
+            'nanostar_amount' => 100,
+        ];
+    }
+
+    protected function assertMinItem($item)
+    {
+        $this->assertEquals(1, $item->getAmount());
+        $this->assertNull($item->getNanostarAmount());
+    }
+
+    protected function assertFullItem($item)
+    {
+        $this->assertEquals(2, $item->getAmount());
+        $this->assertEquals(100, $item->getNanostarAmount());
+    }
+}

--- a/tests/Types/UniqueGiftBackdropColorsTest.php
+++ b/tests/Types/UniqueGiftBackdropColorsTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace TelegramBot\Api\Test\Types;
+
+use TelegramBot\Api\Test\AbstractTypeTest;
+use TelegramBot\Api\Types\UniqueGiftBackdropColors;
+
+class UniqueGiftBackdropColorsTest extends AbstractTypeTest
+{
+    protected static function getType()
+    {
+        return UniqueGiftBackdropColors::class;
+    }
+
+    public static function getMinResponse()
+    {
+        return [
+            'center_color' => 1,
+            'edge_color' => 2,
+            'symbol_color' => 3,
+            'text_color' => 4,
+        ];
+    }
+
+    public static function getFullResponse()
+    {
+        return static::getMinResponse();
+    }
+
+    protected function assertMinItem($item)
+    {
+        $this->assertEquals(1, $item->getCenterColor());
+        $this->assertEquals(2, $item->getEdgeColor());
+        $this->assertEquals(3, $item->getSymbolColor());
+        $this->assertEquals(4, $item->getTextColor());
+    }
+
+    protected function assertFullItem($item)
+    {
+        $this->assertMinItem($item);
+    }
+}

--- a/tests/Types/UniqueGiftBackdropTest.php
+++ b/tests/Types/UniqueGiftBackdropTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace TelegramBot\Api\Test\Types;
+
+use TelegramBot\Api\Test\AbstractTypeTest;
+use TelegramBot\Api\Types\UniqueGiftBackdrop;
+
+class UniqueGiftBackdropTest extends AbstractTypeTest
+{
+    protected static function getType()
+    {
+        return UniqueGiftBackdrop::class;
+    }
+
+    public static function getMinResponse()
+    {
+        return [
+            'name' => 'backdrop',
+            'colors' => UniqueGiftBackdropColorsTest::getMinResponse(),
+            'rarity_per_mille' => 1,
+        ];
+    }
+
+    public static function getFullResponse()
+    {
+        return static::getMinResponse();
+    }
+
+    protected function assertMinItem($item)
+    {
+        $this->assertEquals('backdrop', $item->getName());
+        $this->assertEquals(UniqueGiftBackdropColorsTest::createMinInstance(), $item->getColors());
+        $this->assertEquals(1, $item->getRarityPerMille());
+    }
+
+    protected function assertFullItem($item)
+    {
+        $this->assertMinItem($item);
+    }
+}

--- a/tests/Types/UniqueGiftInfoTest.php
+++ b/tests/Types/UniqueGiftInfoTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace TelegramBot\Api\Test\Types;
+
+use TelegramBot\Api\Test\AbstractTypeTest;
+use TelegramBot\Api\Types\UniqueGiftInfo;
+
+class UniqueGiftInfoTest extends AbstractTypeTest
+{
+    protected static function getType()
+    {
+        return UniqueGiftInfo::class;
+    }
+
+    public static function getMinResponse()
+    {
+        return [
+            'gift' => UniqueGiftTest::getMinResponse(),
+            'origin' => 'upgrade',
+        ];
+    }
+
+    public static function getFullResponse()
+    {
+        return [
+            'gift' => UniqueGiftTest::getMinResponse(),
+            'origin' => 'upgrade',
+            'owned_gift_id' => 'id',
+            'transfer_star_count' => 3,
+        ];
+    }
+
+    protected function assertMinItem($item)
+    {
+        $this->assertEquals(UniqueGiftTest::createMinInstance(), $item->getGift());
+        $this->assertEquals('upgrade', $item->getOrigin());
+        $this->assertNull($item->getOwnedGiftId());
+        $this->assertNull($item->getTransferStarCount());
+    }
+
+    protected function assertFullItem($item)
+    {
+        $this->assertEquals(UniqueGiftTest::createMinInstance(), $item->getGift());
+        $this->assertEquals('upgrade', $item->getOrigin());
+        $this->assertEquals('id', $item->getOwnedGiftId());
+        $this->assertEquals(3, $item->getTransferStarCount());
+    }
+}

--- a/tests/Types/UniqueGiftModelTest.php
+++ b/tests/Types/UniqueGiftModelTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace TelegramBot\Api\Test\Types;
+
+use TelegramBot\Api\Test\AbstractTypeTest;
+use TelegramBot\Api\Types\UniqueGiftModel;
+
+class UniqueGiftModelTest extends AbstractTypeTest
+{
+    protected static function getType()
+    {
+        return UniqueGiftModel::class;
+    }
+
+    public static function getMinResponse()
+    {
+        return [
+            'name' => 'model',
+            'sticker' => StickerTest::getMinResponse(),
+            'rarity_per_mille' => 1,
+        ];
+    }
+
+    public static function getFullResponse()
+    {
+        return static::getMinResponse();
+    }
+
+    protected function assertMinItem($item)
+    {
+        $this->assertEquals('model', $item->getName());
+        $this->assertEquals(StickerTest::createMinInstance(), $item->getSticker());
+        $this->assertEquals(1, $item->getRarityPerMille());
+    }
+
+    protected function assertFullItem($item)
+    {
+        $this->assertMinItem($item);
+    }
+}

--- a/tests/Types/UniqueGiftSymbolTest.php
+++ b/tests/Types/UniqueGiftSymbolTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace TelegramBot\Api\Test\Types;
+
+use TelegramBot\Api\Test\AbstractTypeTest;
+use TelegramBot\Api\Types\UniqueGiftSymbol;
+
+class UniqueGiftSymbolTest extends AbstractTypeTest
+{
+    protected static function getType()
+    {
+        return UniqueGiftSymbol::class;
+    }
+
+    public static function getMinResponse()
+    {
+        return [
+            'name' => 'symbol',
+            'sticker' => StickerTest::getMinResponse(),
+            'rarity_per_mille' => 1,
+        ];
+    }
+
+    public static function getFullResponse()
+    {
+        return static::getMinResponse();
+    }
+
+    protected function assertMinItem($item)
+    {
+        $this->assertEquals('symbol', $item->getName());
+        $this->assertEquals(StickerTest::createMinInstance(), $item->getSticker());
+        $this->assertEquals(1, $item->getRarityPerMille());
+    }
+
+    protected function assertFullItem($item)
+    {
+        $this->assertMinItem($item);
+    }
+}

--- a/tests/Types/UniqueGiftTest.php
+++ b/tests/Types/UniqueGiftTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace TelegramBot\Api\Test\Types;
+
+use TelegramBot\Api\Test\AbstractTypeTest;
+use TelegramBot\Api\Types\UniqueGift;
+
+class UniqueGiftTest extends AbstractTypeTest
+{
+    protected static function getType()
+    {
+        return UniqueGift::class;
+    }
+
+    public static function getMinResponse()
+    {
+        return [
+            'base_name' => 'gift',
+            'name' => 'unique1',
+            'number' => 1,
+            'model' => UniqueGiftModelTest::getMinResponse(),
+            'symbol' => UniqueGiftSymbolTest::getMinResponse(),
+            'backdrop' => UniqueGiftBackdropTest::getMinResponse(),
+        ];
+    }
+
+    public static function getFullResponse()
+    {
+        return static::getMinResponse();
+    }
+
+    protected function assertMinItem($item)
+    {
+        $this->assertEquals('gift', $item->getBaseName());
+        $this->assertEquals('unique1', $item->getName());
+        $this->assertEquals(1, $item->getNumber());
+        $this->assertEquals(UniqueGiftModelTest::createMinInstance(), $item->getModel());
+        $this->assertEquals(UniqueGiftSymbolTest::createMinInstance(), $item->getSymbol());
+        $this->assertEquals(UniqueGiftBackdropTest::createMinInstance(), $item->getBackdrop());
+    }
+
+    protected function assertFullItem($item)
+    {
+        $this->assertMinItem($item);
+    }
+}


### PR DESCRIPTION
## Summary
- add many missing types for stories, paid media, menu buttons, bot command scopes, etc.
- implement `ReactionTypePaid` and tests

## Testing
- `./vendor/bin/simple-phpunit --version` *(fails: command not found)*